### PR TITLE
Fast lock-free stack and flex-array.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,7 +4,7 @@ noinst_PROGRAMS = examples/basic examples/set1 examples/hashable examples/queue
 # 64-bit systems will complain up the wazoo about the 128-bit CAS operations.
 # Yes, they won't be lock free, but they will be sufficiently fast, thanks.
 libhatrack_a_CFLAGS  = -Wall -Wextra -Wno-atomic-alignment -Wno-unused-parameter  -I./include/
-libhatrack_a_SOURCES = src/mmm.c src/debug.c src/xxhash.c src/counters.c src/hatrack_common.c src/refhat.c src/duncecap.c src/swimcap.c src/newshat.c src/ballcap.c src/hihat.c src/hihat-a.c src/oldhat.c src/lohat.c src/lohat-a.c src/witchhat.c src/woolhat.c src/tophat.c src/crown.c src/tiara.c src/dict.c src/set.c bonus/queue.c bonus/flexarray.c
+libhatrack_a_SOURCES = src/mmm.c src/debug.c src/xxhash.c src/counters.c src/hatrack_common.c src/refhat.c src/duncecap.c src/swimcap.c src/newshat.c src/ballcap.c src/hihat.c src/hihat-a.c src/oldhat.c src/lohat.c src/lohat-a.c src/witchhat.c src/woolhat.c src/tophat.c src/crown.c src/tiara.c src/dict.c src/set.c bonus/queue.c bonus/flexarray.c bonus/llstack.c
 
 lib_LIBRARIES = libhatrack.a
 
@@ -28,7 +28,7 @@ examples_queue_CFLAGS = -Wall -Wextra -I./include
 examples_queue_LDADD = ./libhatrack.a
 
 include_HEADERS = include/hatrack.h 
-pkginclude_HEADERS = include/hatrack/xxhash.h include/hatrack/ballcap.h include/hatrack/config.h include/hatrack/counters.h include/hatrack/debug.h include/hatrack/dict.h include/hatrack/set.h include/hatrack/duncecap.h include/hatrack/hash.h include/hatrack/hatomic.h include/hatrack/hatrack_common.h include/hatrack/hatrack_config.h include/hatrack/hatvtable.h include/hatrack/hihat.h include/hatrack/lohat-a.h include/hatrack/lohat.h include/hatrack/lohat_common.h include/hatrack/mmm.h include/hatrack/newshat.h include/hatrack/oldhat.h include/hatrack/refhat.h include/hatrack/swimcap.h include/hatrack/tophat.h include/hatrack/witchhat.h include/hatrack/woolhat.h include/hatrack/crown.h include/hatrack/tiara.h include/hatrack/queue.h include/hatrack/flexarray.h
+pkginclude_HEADERS = include/hatrack/xxhash.h include/hatrack/ballcap.h include/hatrack/config.h include/hatrack/counters.h include/hatrack/debug.h include/hatrack/dict.h include/hatrack/set.h include/hatrack/duncecap.h include/hatrack/hash.h include/hatrack/hatomic.h include/hatrack/hatrack_common.h include/hatrack/hatrack_config.h include/hatrack/hatvtable.h include/hatrack/hihat.h include/hatrack/lohat-a.h include/hatrack/lohat.h include/hatrack/lohat_common.h include/hatrack/mmm.h include/hatrack/newshat.h include/hatrack/oldhat.h include/hatrack/refhat.h include/hatrack/swimcap.h include/hatrack/tophat.h include/hatrack/witchhat.h include/hatrack/woolhat.h include/hatrack/crown.h include/hatrack/tiara.h include/hatrack/queue.h include/hatrack/flexarray.h include/hatrack/llstack.h
 test: check
 remake: clean all
 format:

--- a/Makefile.am
+++ b/Makefile.am
@@ -4,7 +4,7 @@ noinst_PROGRAMS = examples/basic examples/set1 examples/hashable examples/queue
 # 64-bit systems will complain up the wazoo about the 128-bit CAS operations.
 # Yes, they won't be lock free, but they will be sufficiently fast, thanks.
 libhatrack_a_CFLAGS  = -Wall -Wextra -Wno-atomic-alignment -Wno-unused-parameter  -I./include/
-libhatrack_a_SOURCES = src/mmm.c src/debug.c src/xxhash.c src/counters.c src/hatrack_common.c src/refhat.c src/duncecap.c src/swimcap.c src/newshat.c src/ballcap.c src/hihat.c src/hihat-a.c src/oldhat.c src/lohat.c src/lohat-a.c src/witchhat.c src/woolhat.c src/tophat.c src/crown.c src/tiara.c src/dict.c src/set.c bonus/queue.c bonus/flexarray.c bonus/llstack.c
+libhatrack_a_SOURCES = src/mmm.c src/debug.c src/xxhash.c src/counters.c src/hatrack_common.c src/refhat.c src/duncecap.c src/swimcap.c src/newshat.c src/ballcap.c src/hihat.c src/hihat-a.c src/oldhat.c src/lohat.c src/lohat-a.c src/witchhat.c src/woolhat.c src/tophat.c src/crown.c src/tiara.c src/dict.c src/set.c bonus/queue.c bonus/flexarray.c bonus/llstack.c bonus/stack.c
 
 lib_LIBRARIES = libhatrack.a
 
@@ -28,7 +28,8 @@ examples_queue_CFLAGS = -Wall -Wextra -I./include
 examples_queue_LDADD = ./libhatrack.a
 
 include_HEADERS = include/hatrack.h 
-pkginclude_HEADERS = include/hatrack/xxhash.h include/hatrack/ballcap.h include/hatrack/config.h include/hatrack/counters.h include/hatrack/debug.h include/hatrack/dict.h include/hatrack/set.h include/hatrack/duncecap.h include/hatrack/hash.h include/hatrack/hatomic.h include/hatrack/hatrack_common.h include/hatrack/hatrack_config.h include/hatrack/hatvtable.h include/hatrack/hihat.h include/hatrack/lohat-a.h include/hatrack/lohat.h include/hatrack/lohat_common.h include/hatrack/mmm.h include/hatrack/newshat.h include/hatrack/oldhat.h include/hatrack/refhat.h include/hatrack/swimcap.h include/hatrack/tophat.h include/hatrack/witchhat.h include/hatrack/woolhat.h include/hatrack/crown.h include/hatrack/tiara.h include/hatrack/queue.h include/hatrack/flexarray.h include/hatrack/llstack.h
+pkginclude_HEADERS = include/hatrack/xxhash.h include/hatrack/ballcap.h include/hatrack/config.h include/hatrack/counters.h include/hatrack/debug.h include/hatrack/dict.h include/hatrack/set.h include/hatrack/duncecap.h include/hatrack/hash.h include/hatrack/hatomic.h include/hatrack/hatrack_common.h include/hatrack/hatrack_config.h include/hatrack/hatvtable.h include/hatrack/hihat.h include/hatrack/lohat-a.h include/hatrack/lohat.h include/hatrack/lohat_common.h include/hatrack/mmm.h include/hatrack/newshat.h include/hatrack/oldhat.h include/hatrack/refhat.h include/hatrack/swimcap.h include/hatrack/tophat.h include/hatrack/witchhat.h include/hatrack/woolhat.h include/hatrack/crown.h include/hatrack/tiara.h include/hatrack/queue.h include/hatrack/flexarray.h include/hatrack/llstack.h include/hatrack/stack.h
+
 test: check
 remake: clean all
 format:

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 check_PROGRAMS = tests/test
-noinst_PROGRAMS = examples/basic examples/set1 examples/hashable examples/queue
+noinst_PROGRAMS = examples/basic examples/set1 examples/hashable examples/queue examples/stackex
 
 # 64-bit systems will complain up the wazoo about the 128-bit CAS operations.
 # Yes, they won't be lock free, but they will be sufficiently fast, thanks.
@@ -26,6 +26,10 @@ examples_hashable_LDADD = ./libhatrack.a
 examples_queue_SOURCES = examples/queue.c
 examples_queue_CFLAGS = -Wall -Wextra -I./include
 examples_queue_LDADD = ./libhatrack.a
+
+examples_stackex_SOURCES = examples/stackex.c tests/rand.c
+examples_stackex_CFLAGS = -Wall -Wextra -I./include
+examples_stackex_LDADD = ./libhatrack.a
 
 include_HEADERS = include/hatrack.h 
 pkginclude_HEADERS = include/hatrack/xxhash.h include/hatrack/ballcap.h include/hatrack/config.h include/hatrack/counters.h include/hatrack/debug.h include/hatrack/dict.h include/hatrack/set.h include/hatrack/duncecap.h include/hatrack/hash.h include/hatrack/hatomic.h include/hatrack/hatrack_common.h include/hatrack/hatrack_config.h include/hatrack/hatvtable.h include/hatrack/hihat.h include/hatrack/lohat-a.h include/hatrack/lohat.h include/hatrack/lohat_common.h include/hatrack/mmm.h include/hatrack/newshat.h include/hatrack/oldhat.h include/hatrack/refhat.h include/hatrack/swimcap.h include/hatrack/tophat.h include/hatrack/witchhat.h include/hatrack/woolhat.h include/hatrack/crown.h include/hatrack/tiara.h include/hatrack/queue.h include/hatrack/flexarray.h include/hatrack/llstack.h include/hatrack/stack.h

--- a/Makefile.am
+++ b/Makefile.am
@@ -4,7 +4,7 @@ noinst_PROGRAMS = examples/basic examples/set1 examples/hashable examples/queue
 # 64-bit systems will complain up the wazoo about the 128-bit CAS operations.
 # Yes, they won't be lock free, but they will be sufficiently fast, thanks.
 libhatrack_a_CFLAGS  = -Wall -Wextra -Wno-atomic-alignment -Wno-unused-parameter  -I./include/
-libhatrack_a_SOURCES = src/mmm.c src/debug.c src/xxhash.c src/counters.c src/hatrack_common.c src/refhat.c src/duncecap.c src/swimcap.c src/newshat.c src/ballcap.c src/hihat.c src/hihat-a.c src/oldhat.c src/lohat.c src/lohat-a.c src/witchhat.c src/woolhat.c src/tophat.c src/crown.c src/tiara.c src/dict.c src/set.c bonus/queue.c
+libhatrack_a_SOURCES = src/mmm.c src/debug.c src/xxhash.c src/counters.c src/hatrack_common.c src/refhat.c src/duncecap.c src/swimcap.c src/newshat.c src/ballcap.c src/hihat.c src/hihat-a.c src/oldhat.c src/lohat.c src/lohat-a.c src/witchhat.c src/woolhat.c src/tophat.c src/crown.c src/tiara.c src/dict.c src/set.c bonus/queue.c bonus/flexarray.c
 
 lib_LIBRARIES = libhatrack.a
 
@@ -28,7 +28,7 @@ examples_queue_CFLAGS = -Wall -Wextra -I./include
 examples_queue_LDADD = ./libhatrack.a
 
 include_HEADERS = include/hatrack.h 
-pkginclude_HEADERS = include/hatrack/xxhash.h include/hatrack/ballcap.h include/hatrack/config.h include/hatrack/counters.h include/hatrack/debug.h include/hatrack/dict.h include/hatrack/set.h include/hatrack/duncecap.h include/hatrack/hash.h include/hatrack/hatomic.h include/hatrack/hatrack_common.h include/hatrack/hatrack_config.h include/hatrack/hatvtable.h include/hatrack/hihat.h include/hatrack/lohat-a.h include/hatrack/lohat.h include/hatrack/lohat_common.h include/hatrack/mmm.h include/hatrack/newshat.h include/hatrack/oldhat.h include/hatrack/refhat.h include/hatrack/swimcap.h include/hatrack/tophat.h include/hatrack/witchhat.h include/hatrack/woolhat.h include/hatrack/crown.h include/hatrack/tiara.h include/hatrack/queue.h
+pkginclude_HEADERS = include/hatrack/xxhash.h include/hatrack/ballcap.h include/hatrack/config.h include/hatrack/counters.h include/hatrack/debug.h include/hatrack/dict.h include/hatrack/set.h include/hatrack/duncecap.h include/hatrack/hash.h include/hatrack/hatomic.h include/hatrack/hatrack_common.h include/hatrack/hatrack_config.h include/hatrack/hatvtable.h include/hatrack/hihat.h include/hatrack/lohat-a.h include/hatrack/lohat.h include/hatrack/lohat_common.h include/hatrack/mmm.h include/hatrack/newshat.h include/hatrack/oldhat.h include/hatrack/refhat.h include/hatrack/swimcap.h include/hatrack/tophat.h include/hatrack/witchhat.h include/hatrack/woolhat.h include/hatrack/crown.h include/hatrack/tiara.h include/hatrack/queue.h include/hatrack/flexarray.h
 test: check
 remake: clean all
 format:

--- a/bonus/flexarray.c
+++ b/bonus/flexarray.c
@@ -1,0 +1,453 @@
+/*
+ * Copyright © 2022 John Viega
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License atn
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *  Name:           flexarray.c
+ *  Description:    A fast, wait-free flex array.
+ *
+ *                  This ONLY allows indexing and resizing the array.
+ *                  If you need append/pop operations in addition, see
+ *                  the vector_t type.
+ *
+ *  Author:         John Viega, john@zork.org
+ */
+
+#include <hatrack.h>
+
+static flex_store_t *flexarray_new_store(uint64_t, uint64_t);
+static void          flexarray_migrate(flex_store_t *, flexarray_t *);
+    
+/* The size parameter is the one larger than the largest allowable index.
+ * The underlying store may be bigger-- it will be sized up to the next
+ * power of two.
+ */
+flexarray_t *
+flexarray_new(uint64_t initial_size)
+{
+    flexarray_t *arr;
+
+    arr = (flexarray_t *)malloc(sizeof(flexarray_t));
+    
+    flexarray_init(arr, initial_size);
+    
+    return arr;
+}
+
+void
+flexarray_init(flexarray_t *arr, uint64_t initial_size)
+{
+    uint64_t store_size;
+    
+    arr->ret_callback   = NULL;
+    arr->eject_callback = NULL;
+    store_size          = hatrack_round_up_to_power_of_2(initial_size);
+
+    if (store_size < (1 << FLEXARRAY_MIN_STORE_SZ_LOG)) {
+	store_size = 1 << FLEXARRAY_MIN_STORE_SZ_LOG;
+    }
+    
+    atomic_store(&arr->store, flexarray_new_store(initial_size, store_size));
+
+    return;
+}
+
+void
+flexarray_set_ret_callback(flexarray_t *self, flex_callback_t callback)
+{
+    self->ret_callback = callback;
+
+    return;
+}
+
+void
+flexarray_set_eject_callback(flexarray_t *self, flex_callback_t callback)
+{
+    self->eject_callback = callback;
+}
+
+void
+flexarray_cleanup(flexarray_t *self)
+{
+    flex_store_t *store;
+    uint64_t    i;
+    flex_item_t item;
+
+    store = atomic_load(&self->store);
+    
+    if (self->eject_callback) {
+	for (i = 0; i < store->array_size; i++) {
+	    item = atomic_read(&store->cells[i]);
+	    if (item.state) {
+		(*self->eject_callback)(item.item);
+	    }
+	}
+    }
+
+    mmm_retire_unused(self->store);
+
+    return;
+}
+
+void
+flexarray_delete(flexarray_t *self)
+{
+    flexarray_cleanup(self);
+    free(self);
+
+    return;
+}
+
+void *
+flexarray_get(flexarray_t *self, uint64_t index, int *status)
+{
+    flex_item_t   current;
+    flex_store_t *store;
+    
+    mmm_start_basic_op();
+
+    store = atomic_read(&self->store);
+    
+    if (index >= atomic_read(&store->array_size)) {
+	if (status) {
+	    *status = FLEX_OOB;
+	}
+	return NULL;
+    }
+	
+    current = atomic_read(&store->cells[index]);
+    
+    if (!(current.state & FLEX_ARRAY_USED)) {
+	if (status) {
+	    *status = FLEX_UNINITIALIZED;
+	}
+	return NULL;
+    }
+    
+    if (self->ret_callback && current.item) {
+	(*self->ret_callback)(current.item);
+    }
+    
+    mmm_end_op();
+
+    if (status) {
+	*status = FLEX_OK;
+    }
+    
+    return current.item;
+}
+
+// Returns true if successful, false if write would be out-of-bounds.
+bool
+flexarray_set(flexarray_t *self, uint64_t index, void *item)
+{
+    flex_store_t *store;
+    flex_item_t   current;
+    flex_item_t   candidate;
+    flex_cell_t  *cellptr;
+    
+    mmm_start_basic_op();
+    
+    store = atomic_read(&self->store);
+
+    if (index >= atomic_read(&store->array_size)) {
+	return false;
+    }
+
+    cellptr = &store->cells[index];
+    current = atomic_read(cellptr);
+
+    if (current.state & FLEX_ARRAY_MOVING) {
+	flexarray_migrate(store, self);
+	mmm_end_op();
+	return flexarray_set(self, index, item);
+    }
+
+    candidate.item  = item;
+    candidate.state = FLEX_ARRAY_USED;
+
+    if (CAS(cellptr, &current, candidate)) {
+	if (self->eject_callback && current.state == FLEX_ARRAY_USED) {
+	    (*self->eject_callback)(current.item);
+	}
+	mmm_end_op();
+	return true;
+    }
+
+    if (current.state & FLEX_ARRAY_MOVING) {
+	flexarray_migrate(store, self);
+	mmm_end_op();	
+	return flexarray_set(self, index, item);
+    }
+
+    /* Otherwise, someone beat us to the CAS, but we sequence ourselves
+     * BEFORE the CAS operation (i.e., we got overwritten).
+     */
+
+    if (self->eject_callback) {
+	(*self->eject_callback)(item);
+    }
+    
+    mmm_end_op();
+    return true;
+}
+
+void
+flexarray_set_size(flexarray_t *self, uint64_t index)
+{
+    flex_store_t *store;
+    flex_next_t   next_candidate;
+    flex_next_t   next_expected;
+    uint64_t      array_size;
+    bool          must_retry;
+
+    mmm_start_basic_op();
+
+    store      = atomic_read(&self->store);
+    array_size = atomic_read(&store->array_size);
+
+    /* The 'easy' path is if our store is large enough to handle the
+     * resize, but we're resizing UP.  In that case, we can just
+     * bump up store->array_size and be done.
+     *
+     * It's possible that shrink ops could come in, in parallel.
+     * That's okay; fast-path grows will order before any shrink.
+     */
+    if (index >= array_size && index <= store->store_size) {
+	while (array_size < index) {
+	    if(CAS(&store->array_size, &array_size, index)) {
+		mmm_end_op();
+		return;
+	    }
+	}
+    }
+
+    /* Any time we need more memory, we have to migrate to a new
+     * store.  However, we do the same thing if we are SHRINKING a
+     * store, partially to make it easy to convince ourselves of the
+     * linearization point for each operation.
+     *
+     * Note that there could be multiple set-size operations in
+     * parallel.  Competing GROWS can be folded when possible-- if
+     * there's a grow in progress that's bigger than our desired size,
+     * we can just grow to the larger size.
+     *
+     * Similarly, we can fold SHRINKS.  However, we CANNOT combine the
+     * two, because shrinks conceptually delete cells.
+     * 
+     * However, if there's contention we can linearize any grows
+     * *before* the shrinks.   Therefore, the only times we need to 
+     * do a retry are:
+     *
+     * 1) When we have a late shrink, where the current migration is 
+     *    setting to a higher size than us.
+     *
+     * 2) We have a late grow, where the current migration isn't
+     *    growing the array ENOUGH.
+     */
+
+    next_expected.next_size   = 0;
+    next_expected.next_store  = NULL;
+    next_candidate.next_size  = index;
+    next_candidate.next_store = NULL;
+    must_retry                = false;
+    
+    
+    while (!CAS(&store->next, &next_expected, next_candidate)) {
+	if (next_expected.next_store) {
+	    // We are too late to have a say.  Help migrate.
+	    flexarray_migrate(store, self);
+	    
+	    if (index > store->store_size) {
+		// If we're a grow, we're done if the migration was a shrink
+		// or a larger grow.
+		if ((next_candidate.next_size < store->store_size) ||
+		    index < next_candidate.next_size) {
+		    mmm_end_op();
+		    return;
+		}
+	    } else {
+		// If we're a shrink, we're done if the migration was a
+		// larger shrink.
+		if (next_candidate.next_size < index) {
+		    mmm_end_op();
+		    return;
+		}
+	    }
+	    // Otherwise, we need to retry our operation.
+	    mmm_end_op();
+	    flexarray_set_size(self, index);
+	    return;
+	}
+	/* No store is agreed upon yet, so: 
+	 *
+	 * 1) If we are a grow and we see a bigger grow or a shrink,
+	 *    we are content that our request is served, and we can go
+	 *    help migrate.
+	 *
+	 * 2) If we are a shrink and we see a bigger shrink, we are
+	 *    content that our request is served, and we go help
+	 *    migrate.
+	 *
+	 * Otherwise, we try to install our desired target size again.
+	 */
+
+	if (index > store->store_size) {
+	    if ((next_expected.next_size < store->store_size) ||
+		(next_expected.next_size >= index)) {
+		flexarray_migrate(store, self);
+		mmm_end_op();
+		return;
+	    }
+	}
+	else {
+	    if (next_expected.next_size <= index) {
+		flexarray_migrate(store, self);
+		mmm_end_op();
+		return;
+	    }
+	}
+    }
+    
+    mmm_end_op();
+    
+    return;
+}
+
+static flex_store_t *
+flexarray_new_store(uint64_t array_size, uint64_t store_size)
+{
+    flex_store_t *ret;
+    uint32_t      alloc_len;
+
+    alloc_len = sizeof(flex_store_t) + sizeof(flex_cell_t) * store_size;
+    ret       = (flex_store_t *)mmm_alloc_committed(alloc_len);
+    
+    ret->store_size = store_size;
+
+    atomic_store(&ret->array_size, array_size);
+
+    return ret;
+}
+
+static void
+flexarray_migrate(flex_store_t *store, flexarray_t *top)
+{
+    flex_next_t   expected_next;
+    flex_next_t   candidate_next;
+    flex_store_t *next_store;
+    flex_item_t   expected_item;
+    flex_item_t   candidate_item;
+    uint64_t      i;
+    uint64_t      num_buckets;
+    uint64_t      new_size;
+    
+    if (atomic_read(&top->store) != store) {
+	return;
+    }
+
+    expected_next = atomic_read(&store->next);
+    if (expected_next.next_store) {
+	next_store = expected_next.next_store;
+	goto help_move;
+    }
+
+    // Set those migration bits!
+    for (i = 0; i < store->store_size; i++) {
+	expected_item = atomic_read(&store->cells[i]);
+
+	while (true) {
+	    if (expected_item.state & FLEX_ARRAY_MOVING) {
+		break;
+	    }
+	    if (expected_item.state & FLEX_ARRAY_USED) {
+		candidate_item.state = FLEX_ARRAY_MOVING | FLEX_ARRAY_USED;
+		candidate_item.item  = expected_item.item;
+	    }
+	    else {
+		candidate_item.state = FLEX_ARRAY_MOVING | FLEX_ARRAY_MOVED;
+		candidate_item.item  = NULL;
+	    }
+	    if (CAS(&store->cells[i], &expected_item, candidate_item)) {
+		break;
+	    }
+	}
+    }
+
+    // Now, fight to install the store.
+
+    expected_next = atomic_read(&store->next);
+
+    while (!expected_next.next_store) {
+	
+	num_buckets = hatrack_round_up_to_power_of_2(expected_next.next_size);
+	
+	if (num_buckets < (1 << FLEXARRAY_MIN_STORE_SZ_LOG)) {
+	    num_buckets = 1 << FLEXARRAY_MIN_STORE_SZ_LOG;
+	}
+	
+	next_store = flexarray_new_store(expected_next.next_size, num_buckets);
+	
+	candidate_next.next_store = next_store;
+	candidate_next.next_size  = expected_next.next_size;
+
+	if (CAS(&store->next, &expected_next, candidate_next)) {
+	    goto help_move;
+	}
+
+	mmm_retire_unused(next_store);
+    }
+
+    next_store = expected_next.next_store;
+
+    // Now, help move items that are moving.
+ help_move:
+
+    new_size = expected_next.next_size;
+    
+    for (i = 0; i < store->store_size; i++) {
+	candidate_item = atomic_read(&store->cells[i]);
+	if (candidate_item.state & FLEX_ARRAY_MOVED) {
+	    continue;
+	}
+	
+	if (i < new_size) {
+	    expected_item.item   = NULL;
+	    expected_item.state  = 0;
+	    candidate_item.state = FLEX_ARRAY_USED;
+	    CAS(&next_store->cells[i], &expected_item, candidate_item);
+	    expected_item.item   = candidate_item.item;
+	    expected_item.state  = FLEX_ARRAY_USED|FLEX_ARRAY_MOVING;
+	    CAS(&store->cells[i], &expected_item, candidate_item);
+	    continue;
+	}
+
+	// If there are any items left in the current array, we
+	// eject them, if the callback is set, and we win the CAS.
+	expected_item         = candidate_item;
+	candidate_item.state |= FLEX_ARRAY_MOVED;
+
+	if (CAS(&store->cells[i], &expected_item, candidate_item)) {
+	    if (top->eject_callback) {
+		(*top->eject_callback)(candidate_item.item);
+	    }
+	}
+    }
+
+    // Okay, now swing the store pointer; winner retires the old store!
+    if (CAS(&top->store, &store, next_store)) {
+	mmm_retire(store);
+    }
+
+    return;
+}

--- a/bonus/llstack.c
+++ b/bonus/llstack.c
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2022 John Viega
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License atn
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *  Name:           llstack.c
+ *  Description:    A lock-free, linked-list based stack, primarily for 
+ *                  reference.
+ *
+ *                  This is basically the "classic" lock-free
+ *                  construction, except that we do not need to have
+ *                  an ABA field, due to our use of MMM.
+ *
+ *  Author:         John Viega, john@zork.org
+ */
+
+#include <hatrack.h>
+
+llstack_t *
+llstack_new(void)
+{
+    llstack_t *ret;
+    
+    ret = (llstack_t *)malloc(sizeof(llstack_t));
+
+    llstack_init(ret);
+
+    return ret;
+}
+
+void
+llstack_init(llstack_t *self)
+{
+    atomic_store(&self->head, NULL);
+}
+
+
+void
+llstack_push(llstack_t *self, void *item)
+{
+    llstack_node_t *node;
+    llstack_node_t *head;
+
+    mmm_start_basic_op();
+    
+    node       = mmm_alloc_committed(sizeof(llstack_node_t));
+    head       = atomic_read(&self->head);
+    node->item = item;
+
+    do {
+	node->next = head;
+    } while (!CAS(&self->head, &head, node));
+
+    mmm_end_op();
+    
+    return;
+}
+
+void *
+llstack_pop(llstack_t *self, bool *found)
+{
+    llstack_node_t *old_head;
+
+    mmm_start_basic_op();
+
+    old_head = atomic_read(&self->head);
+
+    while (old_head && !CAS(&self->head, &old_head, old_head->next));
+
+    if (!old_head) {
+	if (found) {
+	    *found = false;
+	}
+
+	mmm_end_op();
+	return NULL;
+    }
+
+    if (found) {
+	*found = true;
+    }
+
+    mmm_retire(old_head);
+    mmm_end_op();
+
+    return old_head->item;
+}

--- a/bonus/stack.c
+++ b/bonus/stack.c
@@ -16,32 +16,98 @@
  *  Name:           stack.c
  *  Description:    A faster stack implementation that avoids
  *                  using a linked list node for each item.
- * 
- *                  We could devise something that is never going to
- *                  copy state when it needs to expand the underlying
- *                  store, breaking the stack up into linked
- *                  segments. For now, I'm not doing that, just to
- *                  keep things as simple as possible.
  *
- *                  Currently this is only going to be lock-free;
- *                  Pushes might need to retry if a pop invalidates
- *                  their cell, and that could happen continually.
+ *                  Note that, if pops start, and have a push start
+ *                  before the pop completes, or an pop end before us,
+ *                  the stack can temporarily end up with dead
+ *                  space... popped items below the head of the stack.
+ *                  Pops therefore need to take dead space into
+ *                  account, and walk down the stack when they see it,
+ *                  until they find something to pop.
+ * 
+ *                  Note that I originally had the ability to do
+ *                  as-you-go compression if a reader ends up walking
+ *                  too far down to pop, and new pushes come in ahead
+ *                  of him.  I was surprised to find that, even with a
+ *                  high pusher to popper ratio, this is sigificantly
+ *                  faster if we just wait to compress out popped
+ *                  cells until we run out of space in the array.
+ *
+ *                  What ended up happening was multiple "gaps" that
+ *                  could be compressed would show up in parallel, and
+ *                  I'd only compress the top one.  So I was making
+ *                  more threads do more work because compression is
+ *                  more complicated, while only modestly lowering the
+ *                  number of migrations I'd ultimately have to do.
+ *
+ *                  So instead of only compressing the top of the
+ *                  stack, and doing it relatively frequently, I now
+ *                  just wait till you run out of space, and then
+ *                  compress the whole thing.
+ *
+ *                  I could use the compression algorithm I was using
+ *                  for this, but instead I do the following:
+ *
+ *                  1) If, after compression, the stack would be more
+ *                     than 1/2 full, I double the size of the stack,
+ *                     and compress into the new store, using the same
+ *                     algorithm I use for migrating hash tables.
+ *
+ *                  2) If, after compression, the stack would be 1/2
+ *                     full or less, instead of compressing in place,
+ *                     I create a new store of the same size, and 
+ *                     compress into that.
+ *
+ *                  When we don't NEED to grow, we could definitely
+ *                  avoid another memory allocation, and possibly some
+ *                  copying.  However, I am pretty sure the extra
+ *                  effort to coordinate an in-place compression isn't
+ *                  worth it; better just to copy.  I may test this at
+ *                  some point.
+ *
+ *                  In the meantime, I have stashed away a version
+ *                  that does in-place compression so I can re-visit
+ *                  it later.
+ *
+ *                  Currently, this algorithm is lock-free; Pushes
+ *                  might need to retry if a pop invalidates their
+ *                  cell, and that could happen continually.
  *
  *                  We could easily address this with a "help"
- *                  facility to caravan operations, but for now
- *                  we're going for simplicity and correctness.
+ *                  facility that keeps pops from asking pushes to
+ *                  retry (and thus from moving the head pointer when
+ *                  done), which risks increasing compressions.  We'll
+ *                  try that out soon.
  *
  *  Author:         John Viega, john@zork.org
  */
 
 #include <hatrack.h>
 
-static stack_store_t *hatstack_new_store        (uint64_t);
-static inline void    hatstack_start_compression(stack_store_t *, hatstack_t *,
-						  uint64_t);
-static inline void    hatstack_help_compress    (stack_store_t *, hatstack_t *);
-static stack_store_t *hatstack_grow_store       (stack_store_t *, hatstack_t *);
-    
+static const stack_item_t proto_item_empty = {
+    .item        = NULL,
+    .state       = 0,
+    .valid_after = 0
+};
+
+static const stack_item_t proto_item_pop = {
+    .item        = NULL,
+    .state       = HATSTACK_POPPED,
+    .valid_after = 0
+};
+
+// For migrations.
+static const stack_item_t proto_item_pushed = {
+    .item        = NULL,
+    .state       = HATSTACK_PUSHED,
+    .valid_after = 0
+};
+
+// clang-format off
+static stack_store_t *hatstack_new_store (uint64_t);
+static stack_store_t *hatstack_grow_store(stack_store_t *, hatstack_t *);
+// clang-format on
+
 hatstack_t *
 hatstack_new(uint64_t prealloc)
 {
@@ -59,96 +125,95 @@ hatstack_init(hatstack_t *self, uint64_t prealloc)
 {
     prealloc = hatrack_round_up_to_power_of_2(prealloc);
 
-    if (prealloc < (1 << HATSTACK_MIN_STORE_SZ_LOG)) {
-	prealloc = 1 << HATSTACK_MIN_STORE_SZ_LOG;
-    }
-
     atomic_store(&self->store, hatstack_new_store(prealloc));
     
-    self->compress_threshold = HATSTACK_DEFAULT_COMPRESS_THRESHOLD;
+    return;
+}
+
+void
+hatstack_cleanup(hatstack_t *self)
+{
+    mmm_retire_unused(atomic_read(&self->store));
 
     return;
 }
 
-/* Since the stack can grow and shrink, we can't assume that the cell
- * we're writing into is totally empty, unless there's a migration in
- * progress. It could also be a pop or a compress.
- */
+void
+hatstack_delete(hatstack_t *self)
+{
+    hatstack_cleanup(self);
+
+    free(self);
+
+    return;
+}
+
 void
 hatstack_push(hatstack_t *self, void *item)
 {
     stack_store_t *store;
     uint64_t       head_state;
-    uint64_t       cid;
+    uint32_t       ix;
+    uint32_t       epoch;
     stack_item_t   candidate;
     stack_item_t   expected;
     
-
-    candidate.item   = item;
-    candidate.offset = 0;
+    candidate      = proto_item_pushed;
+    candidate.item = item;
     
     mmm_start_basic_op();
 
     store = atomic_read(&self->store);
 
     while (true) {
-	/* We remove the CID from head_state, and shift it down to the
-	 * lower bits, so we can detect when a compression is happening.
-	 */
-	
 	head_state = atomic_fetch_add(&store->head_state, 1);
-	cid        = head_state & HATSTACK_HEAD_ISOLATE_CID;
-	cid      >>= 32;
-	head_state = head_state & ~HATSTACK_HEAD_ISOLATE_CID;
+
+	if (head_is_moving(head_state, store->num_cells)) {
+	    store = hatstack_grow_store(store, self);
+	    continue;
+	}
 	
-	if (head_state >= store->num_cells) {
-	    if (head_state & HATSTACK_HEAD_F_COMPRESSING) {
-		hatstack_help_compress(store, self);
-		continue;
-	    }
-	    /* Else, either we're ALREADY migrating, or we need to
-	     * migrate, just go off and migrate, already, then retry
-	     * the operation.
-	     */
-	    store = hatstack_grow_store(store, self);
-	    continue;
-	}
+	epoch                 = head_get_epoch(head_state);
+	ix                    = head_get_index(head_state);
+	expected              = proto_item_empty;
+	candidate.valid_after = epoch - 1;
 
-	expected = atomic_read(&store->cells[head_state]);
-
-	if (expected.state & HATSTACK_MIGRATING) {
-	    store = hatstack_grow_store(store, self);
-	    continue;
-	}
-
-	if ((expected.state & COMPRESSION_MASK) >= cid) {
-	    /* A compression could have started after our fetch and
-	     * add; if it has, we could be REALLY slow and be multiple
-	     * compressions behind.
-	     *
-	     * Instead of worrying about it, just continue; we'll
-	     * bounce back up to the top, and see if we're still
-	     * compressing.
-	     */
-	    continue;
-	}
-
-	/* While this isn't a compression, we want to make sure old,
-	 * laggy compressions know that they're behind.  So instead of
-	 * taking whatever was there, use the one we know what most
-	 * recent.
-	 */
-	candidate.state = cid;
-	    
-	// Usually this will be uncontested, and if so, we are done.
-	if (CAS(&store->cells[head_state], &expected, candidate)) {
+	if (CAS(&store->cells[ix], &expected, candidate)) {
 	    mmm_end_op();
 	    return;
 	}
 
-	/* If we couldn't CAS our item in, then we are either growing or
-	 * compressing, as pushes never compete with each other. In
-	 * that case, we head back up to the top.
+	if (state_is_moving(expected.state)) {
+	    store = hatstack_grow_store(store, self);
+	    continue;
+	}
+	
+	if (!cell_can_push(expected, epoch)) {
+	    /* Once we see that a cell's been invalidated, we want to
+	     * remove the invalidated flag before we move on.  That
+	     * way, if the array successfully shrinks, the bucket can
+	     * be reused, by removing the invalidated flag.  But,
+	     * remember, we can be slow, so we need to make sure the
+	     * 'invalid' flag was meant for us, not for some future
+	     * thread that's also assigned this bucket.
+	     */
+	    continue;
+	}
+
+	// Usually this will be uncontested, and if so, we are done.
+	if (CAS(&store->cells[ix], &expected, candidate)) {
+	    mmm_end_op();
+	    return;
+	}
+
+	/* If we couldn't CAS our item in, we are competing with one
+	 * of two fairly rare things:
+	 *
+	 * 1) A grow operation.
+	 * 2) A faster pop operation that invalidated our bucket.
+	 *
+	 * Whatever the case, we head back up to the top for another
+	 * go.
 	 */
 	continue;
     }
@@ -160,125 +225,117 @@ hatstack_pop(hatstack_t *self, bool *found)
     stack_store_t *store;
     stack_item_t   expected;
     stack_item_t   candidate;
-    uint64_t       consecutive_pops;
     uint64_t       head_state;
+    uint64_t       head_candidate;    
     uint64_t       ix;
-    uint64_t       cid;
+    uint32_t       epoch;
 
     mmm_start_basic_op();
 
-    store            = atomic_read(&self->store);
-    candidate.item   = NULL;
-    candidate.offset = 0;
-			     
-    
-    while (true) {
-	consecutive_pops = 0;
-	head_state       = atomic_read(&store->head_state);
-	cid              = head_state & HATSTACK_HEAD_ISOLATE_CID;
-	cid            >>= 32;
-	ix               = head_state & ~HATSTACK_HEAD_ISOLATE_CID;
-	candidate.state  = HATSTACK_POPPED | cid;
-	
 
-	if (ix >= store->num_cells) {
-	    if (ix & HATSTACK_HEAD_F_COMPRESSING) {
-		hatstack_help_compress(store, self);
+    /* Iteration instead of recursion.  We'll only come back up to the top
+     * loop in the case where we are forced into doing a grow operation,
+     * which only happens in two cases:
+     *
+     * 1) There's already one in progress when we start our operation.
+     *
+     * 2) We cannot pop because a migration is in progress.
+     */
+ top_loop:
+    while (true) {
+	store      = atomic_read(&self->store);
+	head_state = atomic_read(&store->head_state);
+	candidate  = proto_item_pop;	
+
+	if (head_is_moving(head_state, store->num_cells)) {
+	    store = hatstack_grow_store(store, self);
+	    continue;
+	}
+	
+	ix                    = head_get_index(head_state);
+	epoch                 = head_get_epoch(head_state);
+	expected              = proto_item_empty;
+	candidate.valid_after = epoch;
+
+	/* ix points to the next push location, so if it's at 0 the
+	 * stack is empty.  If we're not at 0, we substract 1.
+	 */
+	if (!ix) {
+	    return hatstack_not_found(found);
+	}
+
+	ix = ix - 1; 
+
+	/* First, let's assume the top of the stack is clean, and that
+	 * we're racing pushes.  We can use proto_item_empty for
+	 * expected and blindly try to swap.  After that finally
+	 * fails, when we move to new cells we should read from them
+	 * before trying to swap into them, since we won't be in a
+	 * great position to guess the state.
+	 */
+	while (CAS(&store->cells[ix], &expected, candidate)) {
+	    if (ix--) {
 		continue;
 	    }
-	    store = hatstack_grow_store(store, self);
-	    continue;
+	    return hatstack_not_found(found);
 	}
-
-	/* We only iterate through the top parts when we're retrying 
-	 * after a grow or a migration.  When we come jump up to here,
-	 * it's because we saw a POP and kept going down the stack.
-	 */ 
-    organic_next:
-	ix -= 1;
-
-	expected = atomic_read(&store->cells[ix]);
-
-	if (expected.state & HATSTACK_MIGRATING) {
-	    store = hatstack_grow_store(store, self);
-	    continue;
-	}
-
-	if ((expected.state & COMPRESSION_MASK) >= cid) {
-	    continue;
-	}
-
-	if ((expected.state & HATSTACK_POPPED)) {
-	    if (!ix) {
-		if (CAS(&store->head_state, &head_state, cid << 32)) {
-		    if (found) {
-			*found = false;
-		    }
-		    return NULL;
-		}
-		
-		consecutive_pops++;
-		
-		if (consecutive_pops >= self->compress_threshold) {
-		    hatstack_start_compression(store, self, head_state);
-		}
-		
-		if (found) {
-		    *found = false;
-		}
-		return NULL;
-	    }
-	    else {
-		goto organic_next;
-	    }
-	}
-
-	// We think we have something to pop, but there could be contention.
-	if (CAS(&store->cells[ix], &expected, candidate)) {
-	    if (found) {
-		*found = true;
-	    }
-
-	    mmm_end_op();
-	    
-	    return expected.item;
-	}
-
-	/* We failed. The question is why. If could be due to another
-	 * pop, a migration, or a compression.  It's also possible
-	 * we'll see both a pop and a compression, but testing for the
-	 * compression is a bit more expensive than testing for the
-	 * pop, and we'll find out about the compression soon enough...
+	
+	/* Go down the stack trying to swap in pops (updating epochs
+	 * where needed), until:
 	 *
-	 * That is, if we see POPPED, we ignore everything else and go
-	 * to organic_next (or, return false if we're at ix 0).
+	 * 1) We manage to swap in a pop where there was an "old 
+              enough" pushed item
+	 * 2) We hit the bottom of the stack.
+	 * 3) We see that the cell we're looking at is FULLY migrated 
+	 *    (we can pop until the cell is fully moved).
+	 *
+	 * We'll start by expecting a "clean" cell that's never been
+	 * written to.  As we load cells that have pops in them, we'll
+	 * bet that the cell below has the same state.
 	 */
-
-
-	if (expected.state & HATSTACK_POPPED) {
-	    if (!ix) {
-		if (found) {
-		    *found = false;
-		}
-		return NULL;
+	while (true) {
+	    if (state_is_moving(expected.state)) {
+		goto top_loop;
 	    }
-	    goto organic_next;
+
+	    if (!state_is_pushed(expected.state)) {
+		if (expected.valid_after >= epoch) {
+		    // We are very slow!
+		    if (ix--) {
+			expected = atomic_read(&store->cells[ix]);
+			continue;
+		    }
+		    return hatstack_not_found(found);
+		}
+
+		if (CAS(&store->cells[ix], &expected, candidate)) {
+		    expected = atomic_read(&store->cells[ix]);
+		    continue;
+		}
+		continue;
+	    }
+
+	    if (CAS(&store->cells[ix], &expected, candidate)) {
+		// We're popping this item. Break out of the loop and
+		// finish up.
+		break; 
+	    }
+	    // Don't care much why we failed; we can move down the
+	    // stack.
+	    if (ix--) {
+		expected = atomic_read(&store->cells[ix]);
+		continue;
+	    }
+	    return hatstack_not_found(found);
 	}
+	
+	// Now try to swing the head.
+	head_candidate = head_candidate_new_epoch(head_state, ix);
 
-	/* At this point, the CAS failed either because of a migration
-	 * or compression; we'll go back up to the top to figure out
-	 * why, and go help, if still appropriate.
-	 */
-	continue;
+	CAS(&store->head_state, &head_state, head_candidate);
+
+	return hatstack_found(found, expected.item);
     }
-}
-
-void
-hatstack_set_compress_threshold(hatstack_t *self, uint64_t threshold)
-{
-    self->compress_threshold = threshold;
-
-    return;
 }
 
 static stack_store_t *
@@ -287,425 +344,26 @@ hatstack_new_store(uint64_t num_cells)
     stack_store_t *ret;
     uint64_t       alloc_len;
 
-    alloc_len      = sizeof(stack_store_t) + num_cells * sizeof(stack_cell_t);
-    ret            = (stack_store_t *)mmm_alloc(alloc_len);
-    ret->num_cells = num_cells;
+    if (num_cells < (1 << HATSTACK_MIN_STORE_SZ_LOG)) {
+	num_cells = 1 << HATSTACK_MIN_STORE_SZ_LOG;
+    }
+    
+    alloc_len       = sizeof(stack_store_t) + num_cells * sizeof(stack_cell_t);
+    ret             = (stack_store_t *)mmm_alloc_committed(alloc_len);
+    ret->num_cells  = num_cells;
+    ret->head_state = ATOMIC_VAR_INIT(head_candidate_new_epoch(0, 0));
 
     return ret;
 }
 
-/* This is called when a thread notices that compression is necessary,
- * yet no compression seemed to be in progress when we read the head
- * state (as determined by having HATSTACK_HEAD_F_COMPRESSING set
- * in the head pointer).
+/* Migration operates pretty similarly to how it's operated in our
+ * other algorithms.
  *
- * Note that pushes do NOT kick off compression, only pops do, and
- * only if they did a whole lot of popping in the face of competing
- * pushes (if there are no competing pushes, they just swing the head
- * pointer).
- */
-static inline void
-hatstack_start_compression(stack_store_t *store,
-			   hatstack_t *top,
-			   uint64_t expected)
-{
-    uint64_t desired;
-
-    /* Flags aren't set if we're here.  Since the compression ID is
-     * shifted 32 bits up to make room for the actual index of the
-     * head, we add HATSTACK_HEAD_CID_ADD, which is 1 << 32.
-     */
-    desired  = expected + (HATSTACK_HEAD_F_COMPRESSING | HATSTACK_HEAD_CID_ADD);
-
-    // If we've used the maximum compression ID, then we force a migration.
-    if (desired & HATSTACK_HEAD_F_MIGRATING) {
-	store = hatstack_grow_store(store, top);
-    }
-
-    while (!CAS(&store->head_state, &expected, desired)) {
-	if (expected & HATSTACK_HEAD_F_MIGRATING) {
-	    // We can give up; migration in progress will also compress.
-	    return;
-	}
-	
-	if (expected & HATSTACK_HEAD_F_COMPRESSING) {
-	    // Another thread started a compression first. Go help.
-	    hatstack_help_compress(store, top);
-	    return;
-	}
-	
-	/* If the compression ID is higher than ours, we were very
-	 * late to the party, and we're done.
-	 */
-	if ((expected & HATSTACK_HEAD_ISOLATE_CID) >=
-	    (desired & HATSTACK_HEAD_ISOLATE_CID)) {
-	    return;
-	}
-	
-	/* We look to see if the head index is lower than we had
-	 * seen; if it is, some faster pop didn't hit the threshold
-	 * for a compression, and managed to swing the head index
-	 * successfully.
-	 */
-	if ((expected & 0xffffffff00000000) < (desired & 0xffffffff00000000)) {
-	    return;
-	}
-	/*
-	 * Otherwise, keep trying on the CAS, because we lost to a
-	 * push operation, not a compression or migrate.
-	 *
-	 */
-
-	
-    }
-    
-    hatstack_help_compress(store, top);
-
-    return;
-}
-
-    /* We need to coordinate in-place compression, knowing that
-     * other threads may be trying to help at the same time. Each
-     * thread needs to be clear as to what the state of any node is,
-     * and we need to make sure that, if a thread gets suspended for a
-     * long time, and wakes up after a compression is done, they don't
-     * try to proceed as if the compression still needs to happen.
-     * In fact, we might have multiple compressions in quick succession.
-     *
-     * To support this, we will want to:
-     *
-     * 1) Write a "compression ID" into the state field, for cells
-     *    that we mark, which increments once per compression in a
-     *    store, so that we can detect when we're looking at something
-     *    stale.  We will not remove this ID until a later compression
-     *    operation.
-     *
-     *    The compression ID is the least significant 16 bits of
-     *    the state field, and if the compression ID wraps around,
-     *    we migrate instead.
-     *
-     *    We write the compression ID into cells right-to-left, from
-     *    the (now locked) head, down to the point where SOME thread
-     *    finds at least compress_threshold consecutive cells marked
-     *    as popped. 
-     *
-     *    Note that, because we will be migrating the contents of
-     *    cells, not every thread may see the full number of pops.
-     *    Therefore:
-     *
-     * 2) We set a "BACKSTOP" bit in the cell to the left of the last
-     *    pop (along w/ the compression ID), signaling  to other threads 
-     *    that they don't need to go down any farther.  If the entire
-     *    stack is empty, no BACKSTOP bit will be set.
-     *
-     * 3) As we compress, threads iterate, doing the following:
-     *    a) Find the leftmost pop that is to the right of the 
-     *       backstop.
-     *    b) Find the leftmost value to the right of the leftmost pop.
-     *    c) Based on the indexes in a and b, write into the value's 
-     *       state the offset by which we want to move the value.
-     *    d) Copy the contents in the value, into the popped location
-     *       (including the compression ID).
-     *    e) Replace the value we just coppied with a pop (again,
-     *       including the compression ID).
-     *
-     * 4) When were are no more values to move, the rest of the values
-     *    are pops.  Replace them with HATSTACK_OK, but leaving in the 
-     *    compression ID.
-     *
-     * 5) Swap in the new location of head_state, also removing the 
-     *
-     *    Essentially, if we were doing this in a single-threaded
-     *    manner, we're just swapping the HATSTACK_COMPRESSING bit.
-     *
-     * Threads can stall out and wake up at any point during this
-     * process, so we need to make sure there's no ability to get
-     * confused, and write the wrong data.
-     *
-     * First, note that, if a thread gets suspended, and doesn't wake
-     * up until after the migration gets done, either:
-     *
-     * 1) They see that some slot has a "future" compression ID, in
-     *    which case they know they're way behind, and can abandon 
-     *    their work all together.
-     *
-     * 2) They see state with the current compression ID, but other
-     *    than what they're expecting, in which case they know they're
-     *    behind, and forego the operation.
-     *
-     * Also note that, once a cell has been involved in a compression,
-     * the compression ID field will ALWAYS be in a cell.
-     *
-     * Let's consider the cases when a thread lags in the compression,
-     * but is not so tardy as to see a new compression.
-     *
-     * They might stall when writing initial compression IDs and
-     * counting pops. There's some chance they mis-count pops, but the
-     * fastest thread will have added a backstop bit, and the backstop
-     * bit would only get removed if it's overwritten when writing the
-     * compression ID of another compression, in which case the thread
-     * will notice that it's way behind.
-     *
-     * They might stall when trying to move items down the array. And,
-     * the move is a two-phase process, since we cannot directly swap
-     * two cells atomically.  We therefore either have to have two
-     * copies of the data in the array for a limited time, or we need
-     * to delete the item from the array and re-insert it. We do the
-     * former, but either way could work.  We simply write the index
-     * with which we're paired into the other cell, before doing the
-     * swap. This ensures that threads coming in when the stack is in
-     * an inconsistent state have a way of knowing whether they're
-     * behind.
-     *
-     * Specifically, in our case, an array item X could both have
-     * successfully been moved, and still in its own location. A late
-     * arriving thread might find an empty bucket at index I, and
-     * still see X. But the index written into X's cell won't be I, so
-     * they'll know the cell is in the process of being deleted, and
-     * attempt to help with the deletion before moving on.
-     */
-
-static inline void
-hatstack_help_compress(stack_store_t *store, hatstack_t *top)
-{
-    uint32_t     max_index;
-    uint32_t     read_cid;
-    uint32_t     consecutive_pops;
-    uint32_t     ix;
-    uint32_t     scan_ix;
-    uint32_t     offset;
-    uint64_t     compressid;
-    uint64_t     candidate_headstate;
-    uint64_t     headstate;    
-    stack_item_t expected;
-    stack_item_t candidate;
-    stack_item_t scanned;
-
-    headstate  = atomic_read(&store->head_state);
-
-    if (!(headstate & HATSTACK_HEAD_F_COMPRESSING)) {
-	// Already done by the time we got here.
-	return;
-    }
-			     
-    max_index  = headstate & 0xffffffff;
-    compressid = (headstate >> 32) & COMPRESSION_MASK; // Clear the top 2 bits.
-
-    if (max_index >= store->num_cells) {
-	max_index = store->num_cells - 1;
-    }
-    
-    consecutive_pops = 0;
-    ix               = max_index;
-
-    /* This loop marks all the cells involved with the compression,
-     * by swapping in the current compression sequence ID into
-     * the cell. 
-     *
-     * Once we reach the backstop we can stop; and if we see enough
-     * consecutive pops, we write the backstop (if necessary) into
-     * the first NON-pop item.
-     *
-     * We're going to want to start compressing into popped slots
-     * though, so when we leave the loop, make sure ix is pointing
-     * to the popped slot, not the cell with the backstop.
-     */
-    while (true) {
-	expected = atomic_read(&store->cells[ix]);
-	read_cid = expected.state & COMPRESSION_MASK;
-
-	if ((read_cid) > compressid) {
-	    // We're at least a full compression behind.  Yikes!
-	    return;
-	}
-
-	if (expected.state & HATSTACK_POPPED) {
-	    consecutive_pops++;
-	} else {
-	    if (consecutive_pops < top->compress_threshold) {
-		consecutive_pops = 0;
-	    }
-	}
-	
-	if (read_cid == compressid) {
-	    if ((expected.state & HATSTACK_BACKSTOP) || !ix) {
-		/* We found the backstop at the current index, or
-		 * we're at the bottom of the stack.
-		 */
-		break;
-	    }
-	    ix--;
-	    continue;
-	}
-
-	candidate.item    = expected.item;
-	candidate.state   = compressid;
-	candidate.offset  = 0;
-
-	if (expected.state & HATSTACK_POPPED) {
-	    candidate.state |= HATSTACK_POPPED;
-	}
-	else {
-	    if (consecutive_pops >= top->compress_threshold) {
-		candidate.state |= HATSTACK_BACKSTOP;
-	    }
-	}
-
-	CAS(&store->cells[ix], &expected, candidate);
-	if (candidate.state & HATSTACK_BACKSTOP) {
-	    ix++;
-	    break;
-	}
-	
-	// Stack is empty, so no backstop was set.
-	if (!ix) {
-	    break;
-	}
-	
-	ix--;
-	continue;
-    }
-
-    scan_ix = ix + top->compress_threshold;
-
-    while (scan_ix <= max_index) {
-	expected = atomic_read(&store->cells[ix]);
-	read_cid = expected.state & COMPRESSION_MASK;
-
-	if ((read_cid) > compressid) {
-	    return;
-	}
-
-	if (!(expected.state & HATSTACK_POPPED)) {
-	    // Another thread is ahead of us and migrated
-	    // something here.
-	    ix++;
-	    continue;
-	}
-	
-	/* This loop scans for the first item we could possibly move.
-	 * Note that, if we are slow, the item we should have moved
-	 * into the slot at ix might be gone.  
-	 *
-	 * That's okay; we'll line ourselves up to the next available
-	 * item, and will fail to swap it in at the end.  We will look
-	 * to see if we were trying to swap in the wrong item, and NOT
-	 * skip our scan_ix past the wrong item, if that's the case.
-	 */
-	while (true) {
-	    scanned = atomic_read(&store->cells[scan_ix]);
-
-	    // Make sure we're not TOO far behind.
-	    if ((scanned.state & COMPRESSION_MASK) != compressid) {
-		return;
-	    }
-
-	    if (scanned.state & HATSTACK_POPPED) {
-	    scan_next_cell:
-		scan_ix++;
-		if (scan_ix > max_index) {
-		    goto finish_up;
-		}
-		continue;
-	    }
-	    break;
-	}
-	offset = scan_ix - ix;
-	
-	/* If this condition is true, then some thread
-	 * successfully coppied this cell, but has not finished
-	 * replacing it with a pop.  We try to help them out.
-	 */
-	if (scanned.offset && (scanned.offset != offset)) {		
-	    candidate.item   = NULL;
-	    candidate.state  = compressid & HATSTACK_POPPED;
-	    candidate.offset = 0;
-	    CAS(&store->cells[scan_ix], &scanned, candidate);
-	    
-	    goto scan_next_cell;
-	}
-	
-	/* If we're here, the current cell needs to be moved.
-	 * First, if the offset isn't set, try to set it. If
-	 * we fail, we got beat.
-	 */
-	
-	if (!scanned.offset) {
-	    candidate        = scanned;
-	    candidate.offset = offset;
-	    if (CAS(&store->cells[scan_ix], &scanned, candidate)) {
-		scanned = candidate;
-	    } else {
-		if ((scanned.state & COMPRESSION_MASK) != compressid) {
-		    return;
-		}
-	    }
-	}
-	
-	/* Now, try to write the value from the scanned cell
-	 * into the cell that's at ix. 
-	 *
-	 * The offset field gets coppied into the new slot to show
-	 * where we coppied it from, allowing late threads to make
-	 * sure they were working on the right item.
-	 *
-	 * That is, they could have gotten stalled after reading the
-	 * item at ix, someone could have finished the move, and so
-	 * the item at scan_ix is actually further up the array than
-	 * the item that got coppied into the slot at ix.
-	 */
-	candidate.item   = scanned.item;
-	candidate.state  = compressid;
-	candidate.offset = offset;
-	if (CAS(&store->cells[ix], &expected, candidate)) {
-	    expected = candidate;
-	}
-	
-	/* Now, try to replace the scanned cell w/ a pop.  Someone
-	 * else may have done it already, and in fact, it could
-	 * already be replaced with a "new" item if we're maximally
-	 * compressed up to this cell.
-	 */
-	candidate.item   = NULL;
-	candidate.state  = HATSTACK_POPPED | compressid;
-	candidate.offset = 0;
-	CAS(&store->cells[scan_ix], &scanned, candidate);
-	
-	// That cell's done; advance ix.
-	ix++;
-
-	/* If we were working on the wrong item, we will still move
-	 * the current item, so don't advance scan_ix.
-	 */
-	if (expected.offset == offset) {
-	    scan_ix++;
-	    continue;
-	}
-	
-	continue;
-    }
-
- finish_up:
-    /* ix is definitely now pointing to an empty item, which is where
-     * the head state should always point.
-     */
-    candidate_headstate = (compressid << 32) | ix;
-    CAS(&store->head_state, &headstate, candidate_headstate);
-
-    return;
-}
-
-/* Migration is easier than compression; in fact, it operates pretty
- * similarly to how it's operated in our other algorithms.
- *
- * The only complication is that we could end up having a compression
- * operation start in parallel with a grow operation, which we handle
- * by using the head state as a gatekeeper in front of the operation.
- *
- * The migration first tries to get HATSTACK_HEAD_F_MIGRATING set.  If
- * it sees HATSTACK_HEAD_F_COMPRESSING instead, it goes off and helps
- * do that, and abandons the migration (it may get re-triggered on a
- * future push, but ideally the compression created some space).
+ * 1) Mark all the buckets.
+ * 2) Agree on a new store.
+ * 3) Migrate the contents to the new store, marking the old
+ *    buckets as fully moved as we do.
+ * 4) Install the new store and clean up.
  */
 static stack_store_t *
 hatstack_grow_store(stack_store_t *store, hatstack_t *top)
@@ -721,7 +379,7 @@ hatstack_grow_store(stack_store_t *store, hatstack_t *top)
     uint64_t       j;
 
     next_store = atomic_read(&top->store);
-    
+
     if (next_store != store) {
 	return next_store;
     }
@@ -732,67 +390,46 @@ hatstack_grow_store(stack_store_t *store, hatstack_t *top)
     }
 
     head_state = atomic_read(&store->head_state);
+    j          = 0;
 
-    /* Since the migration is that last thing that will happen in this
-     * store, we don't have to worry about setting the value of any of
-     * the other head state, beyond the MIGRATING flag. 
-     * 
-     * And we only bail if we see someone managed to trigger a compression
-     * before we triggered our migration... which compels up to help,
-     * WITHOUT bothering to retry after.
-     */
-    do {
-	if (head_state & HATSTACK_HEAD_F_COMPRESSING) {
-	    hatstack_help_compress(store, top);
-	    return store;
-	}
-	
-	target_state = head_state | HATSTACK_HEAD_F_MIGRATING;
-	
-    } while (!CAS(&store->head_state, &head_state, target_state));
-
-    /* If we're here, HATSTACK_HEAD_F_MIGRATING is set, and
-     * HATSTACK_HEAD_F_COMPRESSING is NOT set. No compression is going
-     * to compete at this point.  We basically stick to our usual
-     * approach:
-     *
-     * 1) Mark all the buckets.
-     * 2) Agree on a new store.
-     * 3) Migrate the contents to the new store, marking the old
-     *    buckets as fully moved as we do.
-     * 4) Install the new store and clean up.
-     */
     for (i = 0; i < store->num_cells; i++) {
 	expected_item = atomic_read(&store->cells[i]);
 	while (true) {
-	    if (expected_item.state & HATSTACK_MIGRATING) {
-		break;
-	    }
-	    if (expected_item.state & HATSTACK_POPPED) {
+	    if (state_is_moving(expected_item.state)) { break;  }
+	    
+	    if (!state_is_pushed(expected_item.state)) {
 		candidate_item.item  = NULL;
-		candidate_item.state |= HATSTACK_MIGRATING | HATSTACK_MOVED;
-	    } else {
-		candidate_item        = expected_item;
-		candidate_item.state |= HATSTACK_MIGRATING;
+		candidate_item.state = state_add_moved(expected_item.state);
 	    }
+	    else {
+		candidate_item       = expected_item;
+		candidate_item.state = state_add_moving(expected_item.state);
+	    }
+
 	    if (CAS(&store->cells[i], &expected_item, candidate_item)) {
 		break;
 	    }
 	}
+	if (state_is_pushed(expected_item.state)) {
+	    j++;
+	}
     }
 
     expected_store = NULL;
-    next_store     = hatstack_new_store(store->num_cells << 1);
+
+    if (j < (store->num_cells >> 1)) {
+	next_store     = hatstack_new_store(store->num_cells);	
+    }
+    else {
+	next_store     = hatstack_new_store(store->num_cells << 1);		
+    }
+
 
     /* This is just to make sure threads know for sure whether
      * num_cells has been initialized, since a stack could legitimately
      * have 0 items. 
-     *
-     * COMPRESSING | MIGRATING is otherwise an invalid state, so we
-     * use it to mean we're migrating INTO the store.
      */
-    atomic_store(&next_store->head_state,
-		 HATSTACK_HEAD_F_COMPRESSING | HATSTACK_HEAD_F_MIGRATING);
+    atomic_store(&next_store->head_state, HATSTACK_HEAD_INITIALIZING);
     
     if (!CAS(&store->next_store, &expected_store, next_store)) {
 	mmm_retire_unused(next_store);
@@ -802,27 +439,22 @@ hatstack_grow_store(stack_store_t *store, hatstack_t *top)
  help_move:
     for (i = 0, j = 0; i < store->num_cells; i++) {
 	old_item = atomic_read(&store->cells[i]);
-
-	if (old_item.state & HATSTACK_MOVED) {
-	    if (!(old_item.state & HATSTACK_POPPED)) {
+	
+	if (state_is_moved(old_item.state)) {
+	    if (state_is_pushed(old_item.state)) {
 		j++;
 	    }
 	    continue;
 	}
+
+	expected_item       = proto_item_empty;
+	candidate_item      = proto_item_pushed;
+	candidate_item.item = old_item.item;
 	
-	expected_item.item   = NULL;
-	expected_item.state  = 0;
-	expected_item.offset = 0;
-
-	// Clear out all the fields other than item (compression ID resets).
-	candidate_item.item   = old_item.item;
-	candidate_item.state  = 0;
-	candidate_item.offset = 0;
-
 	CAS(&next_store->cells[j++], &expected_item, candidate_item);
 
-	candidate_item        = old_item;
-	candidate_item.state |= HATSTACK_MOVED;
+	candidate_item       = old_item;
+	candidate_item.state = state_add_moved(old_item.state);
 	
 	CAS(&store->cells[i], &old_item, candidate_item);
     }
@@ -831,7 +463,7 @@ hatstack_grow_store(stack_store_t *store, hatstack_t *top)
      * be set.  0 is the right compression ID, and we don't want
      * either of the status bits set when we're done.
      */
-    target_state = HATSTACK_HEAD_F_COMPRESSING | HATSTACK_HEAD_F_MIGRATING;
+    target_state = HATSTACK_HEAD_INITIALIZING;
     head_state   = j;
     
 
@@ -849,4 +481,3 @@ hatstack_grow_store(stack_store_t *store, hatstack_t *top)
 
     return next_store;
 }
-

--- a/bonus/stack.c
+++ b/bonus/stack.c
@@ -1,0 +1,839 @@
+/*
+ * Copyright © 2022 John Viega
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License atn
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *  Name:           stack.c
+ *  Description:    A faster stack implementation that avoids
+ *                  using a linked list node for each item.
+ * 
+ *                  We could devise something that is never going to
+ *                  copy state when it needs to expand the underlying
+ *                  store, breaking the stack up into linked
+ *                  segments. For now, I'm not doing that, just to
+ *                  keep things as simple as possible.
+ *
+ *                  Currently this is only going to be lock-free;
+ *                  Pushes might need to retry if a pop invalidates
+ *                  their cell, and that could happen continually.
+ *
+ *                  We could easily address this with a "help"
+ *                  facility to caravan operations, but for now
+ *                  we're going for simplicity and correctness.
+ *
+ *  Author:         John Viega, john@zork.org
+ */
+
+#include <hatrack.h>
+
+static stack_store_t *hatstack_new_store        (uint64_t);
+static inline void    hatstack_start_compression(stack_store_t *, hatstack_t *,
+						  uint64_t);
+static inline void    hatstack_help_compress    (stack_store_t *, hatstack_t *);
+static stack_store_t *hatstack_grow_store       (stack_store_t *, hatstack_t *);
+    
+hatstack_t *
+hatstack_new(uint64_t prealloc)
+{
+    hatstack_t *ret;
+
+    ret = (hatstack_t *)malloc(sizeof(hatstack_t));
+
+    hatstack_init(ret, prealloc);
+
+    return ret;
+}
+
+void
+hatstack_init(hatstack_t *self, uint64_t prealloc)
+{
+    prealloc = hatrack_round_up_to_power_of_2(prealloc);
+
+    if (prealloc < (1 << HATSTACK_MIN_STORE_SZ_LOG)) {
+	prealloc = 1 << HATSTACK_MIN_STORE_SZ_LOG;
+    }
+
+    atomic_store(&self->store, hatstack_new_store(prealloc));
+    
+    self->compress_threshold = HATSTACK_DEFAULT_COMPRESS_THRESHOLD;
+
+    return;
+}
+
+/* Since the stack can grow and shrink, we can't assume that the cell
+ * we're writing into is totally empty, unless there's a migration in
+ * progress. It could also be a pop or a compress.
+ */
+void
+hatstack_push(hatstack_t *self, void *item)
+{
+    stack_store_t *store;
+    uint64_t       head_state;
+    uint64_t       cid;
+    stack_item_t   candidate;
+    stack_item_t   expected;
+    
+
+    candidate.item   = item;
+    candidate.offset = 0;
+    
+    mmm_start_basic_op();
+
+    store = atomic_read(&self->store);
+
+    while (true) {
+	/* We remove the CID from head_state, and shift it down to the
+	 * lower bits, so we can detect when a compression is happening.
+	 */
+	
+	head_state = atomic_fetch_add(&store->head_state, 1);
+	cid        = head_state & HATSTACK_HEAD_ISOLATE_CID;
+	cid      >>= 32;
+	head_state = head_state & ~HATSTACK_HEAD_ISOLATE_CID;
+	
+	if (head_state >= store->num_cells) {
+	    if (head_state & HATSTACK_HEAD_F_COMPRESSING) {
+		hatstack_help_compress(store, self);
+		continue;
+	    }
+	    /* Else, either we're ALREADY migrating, or we need to
+	     * migrate, just go off and migrate, already, then retry
+	     * the operation.
+	     */
+	    store = hatstack_grow_store(store, self);
+	    continue;
+	}
+
+	expected = atomic_read(&store->cells[head_state]);
+
+	if (expected.state & HATSTACK_MIGRATING) {
+	    store = hatstack_grow_store(store, self);
+	    continue;
+	}
+
+	if ((expected.state & COMPRESSION_MASK) >= cid) {
+	    /* A compression could have started after our fetch and
+	     * add; if it has, we could be REALLY slow and be multiple
+	     * compressions behind.
+	     *
+	     * Instead of worrying about it, just continue; we'll
+	     * bounce back up to the top, and see if we're still
+	     * compressing.
+	     */
+	    continue;
+	}
+
+	/* While this isn't a compression, we want to make sure old,
+	 * laggy compressions know that they're behind.  So instead of
+	 * taking whatever was there, use the one we know what most
+	 * recent.
+	 */
+	candidate.state = cid;
+	    
+	// Usually this will be uncontested, and if so, we are done.
+	if (CAS(&store->cells[head_state], &expected, candidate)) {
+	    mmm_end_op();
+	    return;
+	}
+
+	/* If we couldn't CAS our item in, then we are either growing or
+	 * compressing, as pushes never compete with each other. In
+	 * that case, we head back up to the top.
+	 */
+	continue;
+    }
+}
+
+void *
+hatstack_pop(hatstack_t *self, bool *found)
+{
+    stack_store_t *store;
+    stack_item_t   expected;
+    stack_item_t   candidate;
+    uint64_t       consecutive_pops;
+    uint64_t       head_state;
+    uint64_t       ix;
+    uint64_t       cid;
+
+    mmm_start_basic_op();
+
+    store            = atomic_read(&self->store);
+    candidate.item   = NULL;
+    candidate.offset = 0;
+			     
+    
+    while (true) {
+	consecutive_pops = 0;
+	head_state       = atomic_read(&store->head_state);
+	cid              = head_state & HATSTACK_HEAD_ISOLATE_CID;
+	cid            >>= 32;
+	ix               = head_state & ~HATSTACK_HEAD_ISOLATE_CID;
+	candidate.state  = HATSTACK_POPPED | cid;
+	
+
+	if (ix >= store->num_cells) {
+	    if (ix & HATSTACK_HEAD_F_COMPRESSING) {
+		hatstack_help_compress(store, self);
+		continue;
+	    }
+	    store = hatstack_grow_store(store, self);
+	    continue;
+	}
+
+	/* We only iterate through the top parts when we're retrying 
+	 * after a grow or a migration.  When we come jump up to here,
+	 * it's because we saw a POP and kept going down the stack.
+	 */ 
+    organic_next:
+	ix -= 1;
+
+	expected = atomic_read(&store->cells[ix]);
+
+	if (expected.state & HATSTACK_MIGRATING) {
+	    store = hatstack_grow_store(store, self);
+	    continue;
+	}
+
+	if ((expected.state & COMPRESSION_MASK) >= cid) {
+	    continue;
+	}
+
+	if ((expected.state & HATSTACK_POPPED)) {
+	    if (!ix) {
+		if (CAS(&store->head_state, &head_state, cid << 32)) {
+		    if (found) {
+			*found = false;
+		    }
+		    return NULL;
+		}
+		
+		consecutive_pops++;
+		
+		if (consecutive_pops >= self->compress_threshold) {
+		    hatstack_start_compression(store, self, head_state);
+		}
+		
+		if (found) {
+		    *found = false;
+		}
+		return NULL;
+	    }
+	    else {
+		goto organic_next;
+	    }
+	}
+
+	// We think we have something to pop, but there could be contention.
+	if (CAS(&store->cells[ix], &expected, candidate)) {
+	    if (found) {
+		*found = true;
+	    }
+
+	    mmm_end_op();
+	    
+	    return expected.item;
+	}
+
+	/* We failed. The question is why. If could be due to another
+	 * pop, a migration, or a compression.  It's also possible
+	 * we'll see both a pop and a compression, but testing for the
+	 * compression is a bit more expensive than testing for the
+	 * pop, and we'll find out about the compression soon enough...
+	 *
+	 * That is, if we see POPPED, we ignore everything else and go
+	 * to organic_next (or, return false if we're at ix 0).
+	 */
+
+
+	if (expected.state & HATSTACK_POPPED) {
+	    if (!ix) {
+		if (found) {
+		    *found = false;
+		}
+		return NULL;
+	    }
+	    goto organic_next;
+	}
+
+	/* At this point, the CAS failed either because of a migration
+	 * or compression; we'll go back up to the top to figure out
+	 * why, and go help, if still appropriate.
+	 */
+	continue;
+    }
+}
+
+void
+hatstack_set_compress_threshold(hatstack_t *self, uint64_t threshold)
+{
+    self->compress_threshold = threshold;
+
+    return;
+}
+
+static stack_store_t *
+hatstack_new_store(uint64_t num_cells)
+{
+    stack_store_t *ret;
+    uint64_t       alloc_len;
+
+    alloc_len      = sizeof(stack_store_t) + num_cells * sizeof(stack_cell_t);
+    ret            = (stack_store_t *)mmm_alloc(alloc_len);
+    ret->num_cells = num_cells;
+
+    return ret;
+}
+
+/* This is called when a thread notices that compression is necessary,
+ * yet no compression seemed to be in progress when we read the head
+ * state (as determined by having HATSTACK_HEAD_F_COMPRESSING set
+ * in the head pointer).
+ *
+ * Note that pushes do NOT kick off compression, only pops do, and
+ * only if they did a whole lot of popping in the face of competing
+ * pushes (if there are no competing pushes, they just swing the head
+ * pointer).
+ */
+static inline void
+hatstack_start_compression(stack_store_t *store,
+			   hatstack_t *top,
+			   uint64_t expected)
+{
+    uint64_t desired;
+
+    /* Flags aren't set if we're here.  Since the compression ID is
+     * shifted 32 bits up to make room for the actual index of the
+     * head, we add HATSTACK_HEAD_CID_ADD, which is 1 << 32.
+     */
+    desired  = expected + (HATSTACK_HEAD_F_COMPRESSING | HATSTACK_HEAD_CID_ADD);
+
+    // If we've used the maximum compression ID, then we force a migration.
+    if (desired & HATSTACK_HEAD_F_MIGRATING) {
+	store = hatstack_grow_store(store, top);
+    }
+
+    while (!CAS(&store->head_state, &expected, desired)) {
+	if (expected & HATSTACK_HEAD_F_MIGRATING) {
+	    // We can give up; migration in progress will also compress.
+	    return;
+	}
+	
+	if (expected & HATSTACK_HEAD_F_COMPRESSING) {
+	    // Another thread started a compression first. Go help.
+	    hatstack_help_compress(store, top);
+	    return;
+	}
+	
+	/* If the compression ID is still less than ours, we keep
+	 * trying on the CAS, because we lost to a push operation,
+	 * not a compression or migrate.
+	 *
+	 * Otherwise, we were very late to the party, and we're done.
+	 */
+	if ((expected & HATSTACK_HEAD_ISOLATE_CID) >=
+	    (desired & HATSTACK_HEAD_ISOLATE_CID)) {
+	    return;
+	}
+    }
+    
+    hatstack_help_compress(store, top);
+
+    return;
+}
+
+    /* We need to coordinate in-place compression, knowing that
+     * other threads may be trying to help at the same time. Each
+     * thread needs to be clear as to what the state of any node is,
+     * and we need to make sure that, if a thread gets suspended for a
+     * long time, and wakes up after a compression is done, they don't
+     * try to proceed as if the compression still needs to happen.
+     * In fact, we might have multiple compressions in quick succession.
+     *
+     * To support this, we will want to:
+     *
+     * 1) Write a "compression ID" into the state field, for cells
+     *    that we mark, which increments once per compression in a
+     *    store, so that we can detect when we're looking at something
+     *    stale.  We will not remove this ID until a later compression
+     *    operation.
+     *
+     *    The compression ID is the least significant 16 bits of
+     *    the state field, and if the compression ID wraps around,
+     *    we migrate instead.
+     *
+     *    We write the compression ID into cells right-to-left, from
+     *    the (now locked) head, down to the point where SOME thread
+     *    finds at least compress_threshold consecutive cells marked
+     *    as popped. 
+     *
+     *    Note that, because we will be migrating the contents of
+     *    cells, not every thread may see the full number of pops.
+     *    Therefore:
+     *
+     * 2) We set a "BACKSTOP" bit in the cell to the left of the last
+     *    pop (along w/ the compression ID), signaling  to other threads 
+     *    that they don't need to go down any farther.  If the entire
+     *    stack is empty, no BACKSTOP bit will be set.
+     *
+     * 3) As we compress, threads iterate, doing the following:
+     *    a) Find the leftmost pop that is to the right of the 
+     *       backstop.
+     *    b) Find the leftmost value to the right of the leftmost pop.
+     *    c) Based on the indexes in a and b, write into the value's 
+     *       state the offset by which we want to move the value.
+     *    d) Copy the contents in the value, into the popped location
+     *       (including the compression ID).
+     *    e) Replace the value we just coppied with a pop (again,
+     *       including the compression ID).
+     *
+     * 4) When were are no more values to move, the rest of the values
+     *    are pops.  Replace them with HATSTACK_OK, but leaving in the 
+     *    compression ID.
+     *
+     * 5) Swap in the new location of head_state, also removing the 
+     *
+     *    Essentially, if we were doing this in a single-threaded
+     *    manner, we're just swapping the HATSTACK_COMPRESSING bit.
+     *
+     * Threads can stall out and wake up at any point during this
+     * process, so we need to make sure there's no ability to get
+     * confused, and write the wrong data.
+     *
+     * First, note that, if a thread gets suspended, and doesn't wake
+     * up until after the migration gets done, either:
+     *
+     * 1) They see that some slot has a "future" compression ID, in
+     *    which case they know they're way behind, and can abandon 
+     *    their work all together.
+     *
+     * 2) They see state with the current compression ID, but other
+     *    than what they're expecting, in which case they know they're
+     *    behind, and forego the operation.
+     *
+     * Also note that, once a cell has been involved in a compression,
+     * the compression ID field will ALWAYS be in a cell.
+     *
+     * Let's consider the cases when a thread lags in the compression,
+     * but is not so tardy as to see a new compression.
+     *
+     * They might stall when writing initial compression IDs and
+     * counting pops. There's some chance they mis-count pops, but the
+     * fastest thread will have added a backstop bit, and the backstop
+     * bit would only get removed if it's overwritten when writing the
+     * compression ID of another compression, in which case the thread
+     * will notice that it's way behind.
+     *
+     * They might stall when trying to move items down the array. And,
+     * the move is a two-phase process, since we cannot directly swap
+     * two cells atomically.  We therefore either have to have two
+     * copies of the data in the array for a limited time, or we need
+     * to delete the item from the array and re-insert it. We do the
+     * former, but either way could work.  We simply write the index
+     * with which we're paired into the other cell, before doing the
+     * swap. This ensures that threads coming in when the stack is in
+     * an inconsistent state have a way of knowing whether they're
+     * behind.
+     *
+     * Specifically, in our case, an array item X could both have
+     * successfully been moved, and still in its own location. A late
+     * arriving thread might find an empty bucket at index I, and
+     * still see X. But the index written into X's cell won't be I, so
+     * they'll know the cell is in the process of being deleted, and
+     * attempt to help with the deletion before moving on.
+     */
+
+static inline void
+hatstack_help_compress(stack_store_t *store, hatstack_t *top)
+{
+    uint32_t     max_index;
+    uint32_t     read_cid;
+    uint32_t     consecutive_pops;
+    uint32_t     ix;
+    uint32_t     scan_ix;
+    uint32_t     offset;
+    uint64_t     compressid;
+    uint64_t     candidate_headstate;
+    uint64_t     headstate;    
+    stack_item_t expected;
+    stack_item_t candidate;
+    stack_item_t scanned;
+
+    headstate  = atomic_read(&store->head_state);
+
+    if (!(headstate & HATSTACK_HEAD_F_COMPRESSING)) {
+	// Already done by the time we got here.
+	return;
+    }
+			     
+    max_index  = headstate & 0xffffffff;
+    compressid = (headstate >> 32) & COMPRESSION_MASK; // Clear the top 2 bits.
+
+    if (max_index >= store->num_cells) {
+	max_index = store->num_cells - 1;
+    }
+    
+    consecutive_pops = 0;
+    ix               = max_index;
+
+    /* This loop marks all the cells involved with the compression,
+     * by swapping in the current compression sequence ID into
+     * the cell. 
+     *
+     * Once we reach the backstop we can stop; and if we see enough
+     * consecutive pops, we write the backstop (if necessary) into
+     * the first NON-pop item.
+     *
+     * We're going to want to start compressing into popped slots
+     * though, so when we leave the loop, make sure ix is pointing
+     * to the popped slot, not the cell with the backstop.
+     */
+    while (true) {
+	expected = atomic_read(&store->cells[ix]);
+	read_cid = expected.state & COMPRESSION_MASK;
+
+	if ((read_cid) > compressid) {
+	    // We're at least a full compression behind.  Yikes!
+	    return;
+	}
+
+	if (expected.state & HATSTACK_POPPED) {
+	    consecutive_pops++;
+	} else {
+	    if (consecutive_pops < top->compress_threshold) {
+		consecutive_pops = 0;
+	    }
+	}
+	
+	if (read_cid == compressid) {
+	    if ((expected.state & HATSTACK_BACKSTOP) || !ix) {
+		/* We found the backstop at the current index, or
+		 * we're at the bottom of the stack.
+		 */
+		break;
+	    }
+	    ix--;
+	    continue;
+	}
+
+	candidate.item    = expected.item;
+	candidate.state   = compressid;
+	candidate.offset  = 0;
+
+	if (expected.state & HATSTACK_POPPED) {
+	    candidate.state |= HATSTACK_POPPED;
+	}
+	else {
+	    if (consecutive_pops >= top->compress_threshold) {
+		candidate.state |= HATSTACK_BACKSTOP;
+	    }
+	}
+
+	CAS(&store->cells[ix], &expected, candidate);
+	if (candidate.state & HATSTACK_BACKSTOP) {
+	    ix++;
+	    break;
+	}
+	
+	// Stack is empty, so no backstop was set.
+	if (!ix) {
+	    break;
+	}
+	
+	ix--;
+	continue;
+    }
+
+    scan_ix = ix + top->compress_threshold;
+
+    while (scan_ix <= max_index) {
+	expected = atomic_read(&store->cells[ix]);
+	read_cid = expected.state & COMPRESSION_MASK;
+
+	if ((read_cid) > compressid) {
+	    return;
+	}
+
+	if (!(expected.state & HATSTACK_POPPED)) {
+	    // Another thread is ahead of us and migrated
+	    // something here.
+	    ix++;
+	    continue;
+	}
+	
+	/* This loop scans for the first item we could possibly move.
+	 * Note that, if we are slow, the item we should have moved
+	 * into the slot at ix might be gone.  
+	 *
+	 * That's okay; we'll line ourselves up to the next available
+	 * item, and will fail to swap it in at the end.  We will look
+	 * to see if we were trying to swap in the wrong item, and NOT
+	 * skip our scan_ix past the wrong item, if that's the case.
+	 */
+	while (true) {
+	    scanned = atomic_read(&store->cells[scan_ix]);
+
+	    // Make sure we're not TOO far behind.
+	    if ((scanned.state & COMPRESSION_MASK) != compressid) {
+		return;
+	    }
+
+	    if (scanned.state & HATSTACK_POPPED) {
+	    scan_next_cell:
+		scan_ix++;
+		if (scan_ix > max_index) {
+		    goto finish_up;
+		}
+		continue;
+	    }
+	    break;
+	}
+	offset = scan_ix - ix;
+	
+	/* If this condition is true, then some thread
+	 * successfully coppied this cell, but has not finished
+	 * replacing it with a pop.  We try to help them out.
+	 */
+	if (scanned.offset && (scanned.offset != offset)) {		
+	    candidate.item   = NULL;
+	    candidate.state  = compressid & HATSTACK_POPPED;
+	    candidate.offset = 0;
+	    CAS(&store->cells[scan_ix], &scanned, candidate);
+	    
+	    goto scan_next_cell;
+	}
+	
+	/* If we're here, the current cell needs to be moved.
+	 * First, if the offset isn't set, try to set it. If
+	 * we fail, we got beat.
+	 */
+	
+	if (!scanned.offset) {
+	    candidate        = scanned;
+	    candidate.offset = offset;
+	    if (CAS(&store->cells[scan_ix], &scanned, candidate)) {
+		scanned = candidate;
+	    } else {
+		if ((scanned.state & COMPRESSION_MASK) != compressid) {
+		    return;
+		}
+	    }
+	}
+	
+	/* Now, try to write the value from the scanned cell
+	 * into the cell that's at ix. 
+	 *
+	 * The offset field gets coppied into the new slot to show
+	 * where we coppied it from, allowing late threads to make
+	 * sure they were working on the right item.
+	 *
+	 * That is, they could have gotten stalled after reading the
+	 * item at ix, someone could have finished the move, and so
+	 * the item at scan_ix is actually further up the array than
+	 * the item that got coppied into the slot at ix.
+	 */
+	candidate.item   = scanned.item;
+	candidate.state  = compressid;
+	candidate.offset = offset;
+	if (CAS(&store->cells[ix], &expected, candidate)) {
+	    expected = candidate;
+	}
+	
+	/* Now, try to replace the scanned cell w/ a pop.  Someone
+	 * else may have done it already, and in fact, it could
+	 * already be replaced with a "new" item if we're maximally
+	 * compressed up to this cell.
+	 */
+	candidate.item   = NULL;
+	candidate.state  = HATSTACK_POPPED | compressid;
+	candidate.offset = 0;
+	CAS(&store->cells[scan_ix], &scanned, candidate);
+	
+	// That cell's done; advance ix.
+	ix++;
+
+	/* If we were working on the wrong item, we will still move
+	 * the current item, so don't advance scan_ix.
+	 */
+	if (expected.offset == offset) {
+	    scan_ix++;
+	    continue;
+	}
+	
+	continue;
+    }
+
+ finish_up:
+    /* ix is definitely now pointing to an empty item, which is where
+     * the head state should always point.
+     */
+    candidate_headstate = (compressid << 32) | ix;
+    CAS(&store->head_state, &headstate, candidate_headstate);
+
+    return;
+}
+
+/* Migration is easier than compression; in fact, it operates pretty
+ * similarly to how it's operated in our other algorithms.
+ *
+ * The only complication is that we could end up having a compression
+ * operation start in parallel with a grow operation, which we handle
+ * by using the head state as a gatekeeper in front of the operation.
+ *
+ * The migration first tries to get HATSTACK_HEAD_F_MIGRATING set.  If
+ * it sees HATSTACK_HEAD_F_COMPRESSING instead, it goes off and helps
+ * do that, and abandons the migration (it may get re-triggered on a
+ * future push, but ideally the compression created some space).
+ */
+static stack_store_t *
+hatstack_grow_store(stack_store_t *store, hatstack_t *top)
+{
+    stack_store_t *next_store;
+    stack_store_t *expected_store;
+    stack_item_t   expected_item;
+    stack_item_t   candidate_item;
+    stack_item_t   old_item;
+    uint64_t       head_state;
+    uint64_t       target_state;
+    uint64_t       i;
+    uint64_t       j;
+
+    next_store = atomic_read(&top->store);
+    
+    if (next_store != store) {
+	return next_store;
+    }
+
+    next_store = atomic_read(&store->next_store);
+    if (next_store) {
+	goto help_move;
+    }
+
+    head_state = atomic_read(&store->head_state);
+
+    /* Since the migration is that last thing that will happen in this
+     * store, we don't have to worry about setting the value of any of
+     * the other head state, beyond the MIGRATING flag. 
+     * 
+     * And we only bail if we see someone managed to trigger a compression
+     * before we triggered our migration... which compels up to help,
+     * WITHOUT bothering to retry after.
+     */
+    do {
+	if (head_state & HATSTACK_HEAD_F_COMPRESSING) {
+	    hatstack_help_compress(store, top);
+	    return store;
+	}
+	
+	target_state = head_state | HATSTACK_HEAD_F_MIGRATING;
+	
+    } while (!CAS(&store->head_state, &head_state, target_state));
+
+    /* If we're here, HATSTACK_HEAD_F_MIGRATING is set, and
+     * HATSTACK_HEAD_F_COMPRESSING is NOT set. No compression is going
+     * to compete at this point.  We basically stick to our usual
+     * approach:
+     *
+     * 1) Mark all the buckets.
+     * 2) Agree on a new store.
+     * 3) Migrate the contents to the new store, marking the old
+     *    buckets as fully moved as we do.
+     * 4) Install the new store and clean up.
+     */
+    for (i = 0; i < store->num_cells; i++) {
+	expected_item = atomic_read(&store->cells[i]);
+	while (true) {
+	    if (expected_item.state & HATSTACK_MIGRATING) {
+		break;
+	    }
+	    if (expected_item.state & HATSTACK_POPPED) {
+		candidate_item.item  = NULL;
+		candidate_item.state |= HATSTACK_MIGRATING | HATSTACK_MOVED;
+	    } else {
+		candidate_item        = expected_item;
+		candidate_item.state |= HATSTACK_MIGRATING;
+	    }
+	    if (CAS(&store->cells[i], &expected_item, candidate_item)) {
+		break;
+	    }
+	}
+    }
+
+    expected_store = NULL;
+    next_store     = hatstack_new_store(store->num_cells << 1);
+
+    /* This is just to make sure threads know for sure whether
+     * num_cells has been initialized, since a stack could legitimately
+     * have 0 items. 
+     *
+     * COMPRESSING | MIGRATING is otherwise an invalid state, so we
+     * use it to mean we're migrating INTO the store.
+     */
+    atomic_store(&next_store->head_state,
+		 HATSTACK_HEAD_F_COMPRESSING | HATSTACK_HEAD_F_MIGRATING);
+    
+    if (!CAS(&store->next_store, &expected_store, next_store)) {
+	mmm_retire_unused(next_store);
+	next_store = expected_store;
+    }
+
+ help_move:
+    for (i = 0, j = 0; i < store->num_cells; i++) {
+	old_item = atomic_read(&store->cells[i]);
+
+	if (old_item.state & HATSTACK_MOVED) {
+	    if (!(old_item.state & HATSTACK_POPPED)) {
+		j++;
+	    }
+	    continue;
+	}
+	
+	expected_item.item   = NULL;
+	expected_item.state  = 0;
+	expected_item.offset = 0;
+
+	// Clear out all the fields other than item (compression ID resets).
+	candidate_item.item   = old_item.item;
+	candidate_item.state  = 0;
+	candidate_item.offset = 0;
+
+	CAS(&next_store->cells[j++], &expected_item, candidate_item);
+
+	candidate_item        = old_item;
+	candidate_item.state |= HATSTACK_MOVED;
+	
+	CAS(&store->cells[i], &old_item, candidate_item);
+    }
+
+    /* Install head_state.  The new index will be j; nothing else should
+     * be set.  0 is the right compression ID, and we don't want
+     * either of the status bits set when we're done.
+     */
+    target_state = HATSTACK_HEAD_F_COMPRESSING | HATSTACK_HEAD_F_MIGRATING;
+    head_state   = j;
+    
+
+    CAS(&next_store->head_state, &target_state, head_state);
+
+    /* Finally, install the new store, opening the world back up for
+     * pushes and pops.  Any late ops to the old store will still see
+     * our state as "migrating", but will either quickly figure out
+     * that the store has moved, or will go through the motions and do
+     * no work, because every local cell is marked as moved.
+     */
+    if (CAS(&top->store, &store, next_store)) {
+	mmm_retire(store);
+    }
+
+    return next_store;
+}
+

--- a/examples/stackex.c
+++ b/examples/stackex.c
@@ -1,0 +1,388 @@
+#include <testhat.h>
+#include <hatrack.h>
+#include <stdio.h>
+#include <hatrack/debug.h>
+
+const uint64_t    num_ops       = 1 << 21;
+const uint64_t    fail_multiple = 100;
+_Atomic uint64_t  successful_pops;
+__thread uint64_t cur_pops;
+_Atomic uint64_t  write_total;
+_Atomic uint64_t  read_total;
+_Atomic uint64_t  failed_pops;
+struct timespec   stop_times[HATRACK_THREADS_MAX];
+static gate_t     starting_gate = ATOMIC_VAR_INIT(0);
+
+typedef void (*push_func)(void *, uint64_t);
+typedef uint64_t (*pop_func)(void *, bool *);
+typedef void *(*new_func)(uint64_t);
+typedef void (*del_func)(void *);
+
+typedef struct {
+    char *name;
+    new_func new;
+    push_func push;
+    pop_func  pop;
+    del_func  del;
+    bool      can_prealloc;
+} stack_impl_t;
+
+typedef struct {
+    bool          prealloc;
+    uint64_t      num_ops;
+    uint64_t      producers;
+    uint64_t      consumers;
+    stack_impl_t *implementation;
+    double        elapsed;
+} test_info_t;
+
+// A wrapper for llstack_new to take an (ignored) prealloc argument.
+llstack_t *
+llstack_new_proxy(uint64_t ignore)
+{
+    // Silence that compiler warning the dumb way for now.
+    if (!(ignore ^ ignore))
+        return llstack_new();
+    return NULL;
+}
+
+static stack_impl_t algorithms[] = {
+    {.name         = "llstack",
+     .new          = (new_func)llstack_new_proxy,
+     .push         = (push_func)llstack_push,
+     .pop          = (pop_func)llstack_pop,
+     .del          = (del_func)llstack_delete,
+     .can_prealloc = false},
+    {.name         = "hatstack",
+     .new          = (new_func)hatstack_new,
+     .push         = (push_func)hatstack_push,
+     .pop          = (pop_func)hatstack_pop,
+     .del          = (del_func)hatstack_delete,
+     .can_prealloc = true},
+    {
+        0,
+    },
+};
+
+typedef struct {
+    stack_impl_t *impl;
+    void         *object;
+    uint64_t      start;
+    uint64_t      end; // Don't push the last item... array rules.
+} thread_info_t;
+
+typedef uint64_t thread_params_t[2];
+
+thread_params_t thread_params[] = {{1, 1},
+                                   {2, 2},
+                                   {4, 4},
+                                   {8, 8},
+                                   {2, 1},
+                                   {4, 1},
+                                   {8, 1},
+                                   {1, 2},
+                                   {1, 4},
+                                   {1, 8},
+                                   {0, 0}};
+
+static double
+time_diff(struct timespec *end, struct timespec *start)
+{
+    return ((double)(end->tv_sec - start->tv_sec))
+         + ((end->tv_nsec - start->tv_nsec) / 1000000000.0);
+}
+
+static void
+state_reset(void)
+{
+    for (int i = 0; i < HATRACK_THREADS_MAX; i++) {
+        stop_times[i].tv_sec  = 0;
+        stop_times[i].tv_nsec = 0;
+    }
+
+    atomic_store(&read_total, 0);
+    atomic_store(&write_total, 0);
+    atomic_store(&failed_pops, 0);
+    atomic_store(&successful_pops, 0);
+    return;
+}
+
+void *
+push_thread(void *info)
+{
+    uint64_t       my_total;
+    uint64_t       i;
+    uint64_t       end;
+    thread_info_t *push_info;
+    push_func      push;
+    void          *stack;
+
+    mmm_register_thread();
+
+    push_info = (thread_info_t *)info;
+    push      = push_info->impl->push;
+    my_total  = 0;
+    end       = push_info->end;
+    stack     = push_info->object;
+
+    starting_gate_thread_ready(&starting_gate);
+
+    for (i = push_info->start; i < push_info->end; i++) {
+        my_total += i;
+        (*push)(stack, i);
+    }
+
+    atomic_fetch_add(&write_total, my_total);
+
+    clock_gettime(CLOCK_MONOTONIC, &stop_times[mmm_mytid]);
+    mmm_clean_up_before_exit();
+    free(push_info);
+
+    return NULL;
+}
+
+void *
+pop_thread(void *info)
+{
+    uint64_t       consecutive_pops;
+    uint64_t       my_total;
+    uint64_t       n;
+    uint64_t       target_ops;
+    uint64_t       max_fails;
+    thread_info_t *pop_info;
+    bool           status;
+    pop_func       pop;
+    void          *stack;
+
+    mmm_register_thread();
+
+    pop_info         = (thread_info_t *)info;
+    pop              = pop_info->impl->pop;
+    consecutive_pops = 0;
+    my_total         = 0;
+    target_ops       = pop_info->end;
+    max_fails        = target_ops * fail_multiple;
+    stack            = pop_info->object;
+
+    starting_gate_thread_ready(&starting_gate);
+
+    while (atomic_read(&successful_pops) < target_ops) {
+        while (true) {
+            n = (uint64_t)pop(stack, &status);
+            if (status) {
+                consecutive_pops++;
+                my_total += n;
+            }
+            else {
+                break;
+            }
+        }
+
+        atomic_fetch_add(&successful_pops, consecutive_pops);
+        if (atomic_fetch_add(&failed_pops, 1) >= max_fails) {
+            printf("Reached failure threshold :(\n");
+            break;
+        }
+
+        consecutive_pops = 0;
+    }
+
+    atomic_fetch_add(&read_total, my_total);
+
+    clock_gettime(CLOCK_MONOTONIC, &stop_times[mmm_mytid]);
+    mmm_clean_up_before_exit();
+
+    return NULL;
+}
+
+pthread_t push_threads[HATRACK_THREADS_MAX];
+pthread_t pop_threads[HATRACK_THREADS_MAX];
+
+bool
+test_stack(test_info_t *test_info)
+{
+    uint64_t        i;
+    uint64_t        prealloc_sz;
+    uint64_t        ops_per_thread;
+    uint64_t        num_ops;
+    struct timespec start_time;
+    double          cur, min, max;
+    thread_info_t  *threadinfo;
+    bool            err;
+    void           *stack;
+
+    err = false;
+
+    fprintf(stdout,
+            "%8s, prealloc = %c, # producers = %2llu, # consumers = %2llu: ",
+            test_info->implementation->name,
+            test_info->prealloc ? 'Y' : 'N',
+            test_info->producers,
+            test_info->consumers);
+    fflush(stdout);
+    state_reset();
+
+    prealloc_sz    = test_info->prealloc ? test_info->num_ops : 0;
+    stack          = (*test_info->implementation->new)(prealloc_sz);
+    ops_per_thread = test_info->num_ops / test_info->producers;
+    num_ops        = ops_per_thread * test_info->producers;
+
+    starting_gate_init(&starting_gate);
+
+    for (i = 0; i < test_info->producers; i++) {
+        threadinfo         = (thread_info_t *)malloc(sizeof(thread_info_t));
+        threadinfo->start  = (i * ops_per_thread) + 1;
+        threadinfo->end    = ((i + 1) * ops_per_thread) + 1;
+        threadinfo->object = stack;
+        threadinfo->impl   = test_info->implementation;
+
+        pthread_create(&push_threads[i], NULL, push_thread, (void *)threadinfo);
+    }
+
+    for (i = 0; i < test_info->consumers; i++) {
+        threadinfo         = (thread_info_t *)malloc(sizeof(thread_info_t));
+        threadinfo->end    = num_ops;
+        threadinfo->object = stack;
+        threadinfo->impl   = test_info->implementation;
+
+        pthread_create(&pop_threads[i], NULL, pop_thread, (void *)threadinfo);
+    }
+
+    starting_gate_open_when_ready(&starting_gate,
+                                  test_info->producers + test_info->consumers,
+                                  &start_time);
+
+    for (i = 0; i < test_info->producers; i++) {
+        pthread_join(push_threads[i], NULL);
+    }
+
+    for (i = 0; i < test_info->consumers; i++) {
+        pthread_join(pop_threads[i], NULL);
+    }
+
+    if (write_total != read_total) {
+        fprintf(stdout,
+                "\n  Error: push total (%llu) != pop total (%llu)\n",
+                write_total,
+                read_total);
+        err = true;
+    }
+
+    if (num_ops != successful_pops) {
+        fprintf(stdout,
+                "  Error: # pushes (%llu) != # pops (%llu)\n",
+                num_ops,
+                successful_pops);
+        err = true;
+    }
+
+    fprintf(stdout, "  nil pop()s: %-6llu ", failed_pops);
+
+    min = 0;
+    max = 0;
+
+    for (i = 0; i < HATRACK_THREADS_MAX; i++) {
+        if (stop_times[i].tv_sec || stop_times[i].tv_nsec) {
+            cur = time_diff(&stop_times[i], &start_time);
+
+            if (!min || cur < min) {
+                min = cur;
+            }
+            if (!max || cur > max) {
+                max = cur;
+            }
+        }
+    }
+
+    test_info->elapsed = max;
+    test_info->num_ops = (num_ops * 2);
+
+    fprintf(stdout, "\t%.4f sec\n", max);
+
+    (*test_info->implementation->del)(stack);
+
+    return err;
+}
+
+static const char LINE[]
+    = "-----------------------------------------------------------\n";
+
+void
+format_results(test_info_t *tests, int num_tests, int row_size)
+{
+    int i;
+
+    printf("Algorithm  | Prealloc? | Producers | Consumers | MOps/sec\n");
+
+    for (i = 0; i < num_tests; i++) {
+        if (!(i % row_size)) {
+            printf(LINE);
+        }
+        printf("%-13s", tests[i].implementation->name);
+        printf("%-12s", tests[i].prealloc ? "yes" : "no");
+        printf("%-12llu", tests[i].producers);
+        printf("%-12llu", tests[i].consumers);
+        printf("%-.4f\n", (tests[i].num_ops / tests[i].elapsed) / 1000000);
+    }
+}
+
+int
+main(void)
+{
+    int          num_algos;
+    int          num_params;
+    int          num_tests;
+    int          n;
+    int          row_size;
+    int          i, j;
+    test_info_t *tests;
+
+    num_algos  = 0;
+    num_params = 0;
+    num_tests  = 0;
+    n          = 0;
+
+    for (num_algos = 0; algorithms[num_algos].name; num_algos++) {
+        n++;
+        if (algorithms[num_algos].can_prealloc) {
+            n++;
+        }
+    }
+
+    row_size = n;
+
+    for (num_params = 0; thread_params[num_params][0]; num_params++)
+        ;
+
+    num_tests = n * num_params;
+    tests     = (test_info_t *)malloc(sizeof(test_info_t) * num_tests);
+    n         = 0;
+
+    for (i = 0; i < num_params; i++) {
+        for (j = 0; j < num_algos; j++) {
+            tests[n].prealloc       = false;
+            tests[n].num_ops        = num_ops;
+            tests[n].producers      = thread_params[i][0];
+            tests[n].consumers      = thread_params[i][1];
+            tests[n].implementation = &algorithms[j];
+            n++;
+
+            if (algorithms[j].can_prealloc) {
+                tests[n].prealloc       = true;
+                tests[n].num_ops        = num_ops;
+                tests[n].producers      = thread_params[i][0];
+                tests[n].consumers      = thread_params[i][1];
+                tests[n].implementation = &algorithms[j];
+                n++;
+            }
+        }
+    }
+
+    for (i = 0; i < n; i++) {
+        test_stack(&tests[i]);
+    }
+
+    format_results(tests, n, row_size);
+
+    return 0;
+}

--- a/include/hatrack.h
+++ b/include/hatrack.h
@@ -45,5 +45,6 @@
 
 #include <hatrack/hash.h>
 #include <hatrack/queue.h>
+#include <hatrack/flexarray.h>
 
 #endif

--- a/include/hatrack.h
+++ b/include/hatrack.h
@@ -46,5 +46,5 @@
 #include <hatrack/hash.h>
 #include <hatrack/queue.h>
 #include <hatrack/flexarray.h>
-
+#include <hatrack/llstack.h>
 #endif

--- a/include/hatrack.h
+++ b/include/hatrack.h
@@ -47,4 +47,5 @@
 #include <hatrack/queue.h>
 #include <hatrack/flexarray.h>
 #include <hatrack/llstack.h>
+#include <hatrack/stack.h>
 #endif

--- a/include/hatrack/debug.h
+++ b/include/hatrack/debug.h
@@ -190,6 +190,58 @@ hatrack_debug_ptr(void *addr, char *msg)
     return;
 }
 
+static inline void
+hatrack_debug2(void *addr, void *addr2, char *msg)
+{
+    char buf[HATRACK_PTR_CHRS + HATRACK_PTR_FMT_CHRS + 1] = {
+        '0',
+        'x',
+    };
+    
+    char                   *p = buf + HATRACK_PTR_CHRS + HATRACK_PTR_FMT_CHRS;
+    uint64_t                i;
+    uintptr_t               n = (uintptr_t)addr;
+    char                   *where;
+    char                   *end;
+    uint64_t                mysequence;
+    hatrack_debug_record_t *record_ptr;
+
+    mysequence = atomic_fetch_add(&__hatrack_debug_sequence, 1);
+    record_ptr = &__hatrack_debug[mysequence & HATRACK_DEBUG_RING_LAST_SLOT];
+    end        = record_ptr->msg + HATRACK_DEBUG_MSG_SIZE;
+
+    record_ptr->sequence = mysequence;
+    record_ptr->thread   = mmm_mytid;
+
+    *--p = ' ';
+    *--p = ':';
+
+    for (i = 0; i < HATRACK_PTR_CHRS; i++) {
+        *--p = __hatrack_hex_conversion_table[n & 0xf];
+        n >>= 4;
+    }
+    strcpy(record_ptr->msg, buf);
+
+    p = buf + HATRACK_PTR_CHRS + HATRACK_PTR_FMT_CHRS;
+    n = (uintptr_t)addr2;
+
+    *--p = ' ';
+    *--p = ':';
+
+    for (i = 0; i < HATRACK_PTR_CHRS; i++) {
+        *--p = __hatrack_hex_conversion_table[n & 0xf];
+        n >>= 4;
+    }
+    
+    where = record_ptr->msg + HATRACK_PTR_CHRS + HATRACK_PTR_FMT_CHRS;
+    strncpy(where, buf, end - where);
+
+    where = where + HATRACK_PTR_CHRS + HATRACK_PTR_FMT_CHRS;
+    strncpy(where, msg, end - where);
+	    
+    return;
+}
+
 /* hatrack_debug_assert()
  *
  * This is meant to be called either through the ASSERT() macro, which
@@ -280,6 +332,7 @@ hatrack_debug_assert_w_params(bool        expression_result,
 
 #define DEBUG(x)        hatrack_debug(x)
 #define DEBUG_PTR(x, y) hatrack_debug_ptr((void *)(x), y)
+#define DEBUG2(x, y, m) hatrack_debug2((void *)(x), (void *)(y), m)
 #define ASSERT(x)       hatrack_debug_assert(x, #x, __FUNCTION__, __FILE__, __LINE__)
 #define XASSERT(x, n, b)                                                       \
     hatrack_debug_assert_w_params(x, #x, __FUNCTION__, __FILE__, __LINE__, n, b)
@@ -288,6 +341,7 @@ hatrack_debug_assert_w_params(bool        expression_result,
 
 #define DEBUG(x)
 #define DEBUG_PTR(x, y)
+#define DEBUG2(x, y, m)
 #define ASSERT(x)
 #define XASSERT(x, n, b)
 #endif

--- a/include/hatrack/flexarray.h
+++ b/include/hatrack/flexarray.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2022 John Viega
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License atn
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *  Name:           flexarray.h
+ *  Description:    A fast, wait-free flex array.
+ *
+ *                  This ONLY allows indexing and resizing the array.
+ *                  If you need append/pop operations in addition, see
+ *                  the vector_t type.
+ *
+ *  Author:         John Viega, john@zork.org
+ */
+
+#ifndef __FLEXARRAY_H__
+#define __FLEXARRAY_H__
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdatomic.h>
+#include <hatrack/hatrack_config.h>
+
+
+#define FLEXARRAY_MIN_STORE_SZ_LOG 4
+
+// clang-format off
+typedef void (*flex_callback_t)(void *);
+
+typedef struct {
+    void     *item;
+    uint64_t  state;
+} flex_item_t;
+
+typedef _Atomic flex_item_t flex_cell_t;
+
+typedef struct flex_store_t flex_store_t;
+
+typedef struct {
+    uint64_t      next_size;
+    flex_store_t *next_store;
+} flex_next_t;
+    
+struct flex_store_t {
+    alignas(8)
+    uint64_t              store_size;
+    _Atomic uint64_t      array_size;
+    _Atomic flex_next_t   next;
+    flex_cell_t           cells[];
+};
+
+typedef struct {
+    flex_callback_t          ret_callback;
+    flex_callback_t          eject_callback;
+    _Atomic (flex_store_t  *)store;
+} flexarray_t;
+
+flexarray_t *flexarray_new               (uint64_t);
+void         flexarray_init              (flexarray_t *, uint64_t);
+void         flexarray_set_ret_callback  (flexarray_t *, flex_callback_t);
+void         flexarray_set_eject_callback(flexarray_t *, flex_callback_t);
+void         flexarray_cleanup           (flexarray_t *);
+void         flexarray_delete            (flexarray_t *);
+void        *flexarray_get               (flexarray_t *, uint64_t, int *);
+bool         flexarray_set               (flexarray_t *, uint64_t, void *);
+void         flexarray_set_size          (flexarray_t *, uint64_t);
+uint32_t     flexarray_len               (flexarray_t *);
+
+enum64(flex_enum_t,
+       FLEX_ARRAY_MOVING = 0x4000000000000000,
+       FLEX_ARRAY_MOVED  = 0x2000000000000000,
+       FLEX_ARRAY_USED   = 0x1000000000000000);
+
+enum {
+    FLEX_OK,
+    FLEX_OOB,
+    FLEX_UNINITIALIZED
+};
+
+#endif

--- a/include/hatrack/hatrack_config.h
+++ b/include/hatrack/hatrack_config.h
@@ -637,6 +637,10 @@
 #error "QSIZE_LOG_MAX must be >= QSIZE_LOG_DEFAULT"
 #endif
 
+#ifndef FLEXARRAY_DEFAULT_GROW_SIZE_LOG
+#define FLEXARRAY_DEFAULT_GROW_SIZE_LOG 8
+#endif
+
 #ifdef HAVE_C11_ENUMS
 #define enum64(x, ...)                                                         \
     typedef enum : uint64_t                                                    \

--- a/include/hatrack/llstack.h
+++ b/include/hatrack/llstack.h
@@ -40,9 +40,12 @@ typedef struct {
     _Atomic (llstack_node_t *) head;
 } llstack_t;
 
-llstack_t *llstack_new (void);
-void       llstack_init(llstack_t *);
-void       llstack_push(llstack_t *, void *);
-void      *llstack_pop (llstack_t *, bool *);
+// clang-format off
+llstack_t *llstack_new    (void);
+void       llstack_init   (llstack_t *);
+void       llstack_cleanup(llstack_t *);
+void       llstack_delete (llstack_t *);
+void       llstack_push   (llstack_t *, void *);
+void      *llstack_pop    (llstack_t *, bool *);
 
 #endif

--- a/include/hatrack/llstack.h
+++ b/include/hatrack/llstack.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2022 John Viega
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License atn
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *  Name:           llstack.c
+ *
+ *  Description:    A lock-free, linked-list based stack, primarily for 
+ *                  reference.
+ *
+ *  Author:         John Viega, john@zork.org
+ */
+
+#ifndef __LLSTACK_H__
+#define __LLSTACK_H__
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdatomic.h>
+#include <stdalign.h>
+
+typedef struct llstack_node_t llstack_node_t;
+
+struct llstack_node_t {
+    llstack_node_t *next;
+    void           *item;
+};
+
+typedef struct {
+    _Atomic (llstack_node_t *) head;
+} llstack_t;
+
+llstack_t *llstack_new (void);
+void       llstack_init(llstack_t *);
+void       llstack_push(llstack_t *, void *);
+void      *llstack_pop (llstack_t *, bool *);
+
+#endif

--- a/include/hatrack/stack.h
+++ b/include/hatrack/stack.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2022 John Viega
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License atn
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *  Name:           stack.h
+ *  Description:    A faster stack implementation that avoids
+ *                  using a linked list node for each item.
+ * 
+ *                  We could devise something that is never going to
+ *                  copy state when it needs to expand the underlying
+ *                  store, breaking the stack up into linked
+ *                  segments. For now, I'm not doing that, just to
+ *                  keep things as simple as possible.
+ *                  
+ *
+ *  Author:         John Viega, john@zork.org
+ */
+
+#ifndef __STACK_H__
+#define __STACK_H__
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdatomic.h>
+#include <stdalign.h>
+
+typedef struct {
+    void    *item;
+    uint32_t state;  // 4 bits of flags, 28 bits of a compression ID.
+    uint32_t offset; // During a move, which cell are we moving to?
+} stack_item_t;
+
+typedef _Atomic stack_item_t stack_cell_t;
+typedef struct stack_store_t stack_store_t;
+
+struct stack_store_t {
+    uint64_t                 num_cells;
+    _Atomic uint64_t         head_state;
+    _Atomic (stack_store_t *)next_store;
+    stack_cell_t             cells[];
+};
+
+typedef struct {
+    _Atomic (stack_store_t *)store;
+    uint64_t                 compress_threshold;
+} hatstack_t;
+
+
+hatstack_t *hatstack_new                   (uint64_t);
+void        hatstack_init                  (hatstack_t *, uint64_t);
+void        hatstack_push                  (hatstack_t *, void *);
+void       *hatstack_pop                   (hatstack_t *, bool *);
+void        hatstack_set_compress_threshold(hatstack_t *, uint64_t);
+
+/* These flags live in the head state.  Pushes still FAA to the head
+ * state to get an index, but will immediately decide to help with the
+ * operation, and will know that they overshot.
+ */
+enum {
+    HATSTACK_HEAD_F_COMPRESSING = 0x8000000000000000,
+    HATSTACK_HEAD_F_MIGRATING   = 0x4000000000000000,
+    HATSTACK_HEAD_CID_ADD       = 0x0000000100000000,
+    HATSTACK_HEAD_ISOLATE_CID   = 0x3fffffff00000000
+};
+
+/* These flags are used in the state field of stack_item_t.
+ */
+
+enum {
+    HATSTACK_POPPED      = 0x80000000,
+    HATSTACK_BACKSTOP    = 0x40000000,
+    HATSTACK_MIGRATING   = 0x20000000,
+    HATSTACK_MOVED       = 0x10000000,
+    COMPRESSION_MASK     = 0x3fffffff
+};
+
+
+
+#define HATSTACK_MIN_STORE_SZ_LOG           6
+#define HATSTACK_DEFAULT_COMPRESS_THRESHOLD 1 << 4
+
+
+#endif


### PR DESCRIPTION
I added a fast stack, that eliminates the head contention one sees with the traditional approach (favoring FAA over CAS).  I originally had a complicated in-place compression algorithm to incrementally compress the stack, but it turned out the simpler migration strategy used on the hash tables is better in practice, and simpler.

I will probably still do the little bit of work necessary to make the stack wait-free (at least optionally).

Additionally, I added an initial fast, wait-free flexible array.  It does bounds checking and can be resized up or down.

The flexarray does NOT support push and pop the way C++ vectors do.  I have an algorithm I need to implement that will allow for that, with the random access being almost as fast as flex array, and the push/pop being possible.  When I get to that, it will be called a "vector", not a flexarray.

The two separate constructions will be much faster on their own (especially the stack; there are reasons why the approach for this stack won't work in a vector), but if you need both in one data structure, I'll soon have you covered.