### PR TITLE
Make core capq operations wait-free.

### DIFF
--- a/include/hatrack/capq.h
+++ b/include/hatrack/capq.h
@@ -164,13 +164,9 @@ capq_clear_moving(uint64_t state)
 
 // Precondition-- we are looking at the right epoch.
 static inline bool
-capq_should_return(uint64_t state, uint64_t retries)
+capq_should_return(uint64_t state)
 {
-    if (capq_is_enqueued(state)) {
-	return true;
-    }
-
-    if (capq_is_dequeued(state) && retries >= CAPQ_TOP_CONTEND_THRESHOLD) {
+    if (capq_is_enqueued(state) || capq_is_dequeued(state)) {
 	return true;
     }
 

--- a/include/hatrack/hatrack_config.h
+++ b/include/hatrack/hatrack_config.h
@@ -679,6 +679,43 @@
 #undef HATSTACK_TEST_LLSTACK
 
 
+/* CAPQ_TOP_CONTEND_THRESHOLD
+ * 
+ * On calls to capq_top(), how many times do we retry in the face of
+ * dequeue contention, before we linearize ourselves behind a dequeue?
+ * This is necessary to make capq_top() wait free, but means that we
+ * might return KNOWING that a subsequent call to capq_cap() is going
+ * to fail, causing the caller to do some unnecessary work.
+ *
+ * For most expected uses of CAPQ, it's probably better to minimize
+ * contention, and keep this number low, but I don't have any strong
+ * evidence yet.
+ */
+
+#define CAPQ_TOP_CONTEND_THRESHOLD 4
+
+/* CAPQ_TOP_SUSPEND_THRESHOLD
+ *
+ * If calls to capq_top() find that the underlying backing store is
+ * small enough that we are often looping around before dequeuers have
+ * a chance to see what was in a cell (generally due to dequeuers
+ * getting suspended), then we force a resize of the backing store.
+ *
+ * This variable controls how many times a thread deals with this
+ * condition in a single call to capq_top() before kicking off a
+ * resize.
+ *
+ * This is also necessary for wait freedom.
+ *
+ * I recommend keeping this value greater than 1 (suspended threads
+ * happen), but not much higher, because if a thread hits the same
+ * situation multiple times in succession, there's probably going to
+ * be a lot of contention all around, and it's worth growing the
+ * backing store.
+ */
+
+#define CAPQ_TOP_SUSPEND_THRESHOLD 2
+
 #ifndef FLEXARRAY_DEFAULT_GROW_SIZE_LOG
 #define FLEXARRAY_DEFAULT_GROW_SIZE_LOG 8
 #endif

--- a/include/hatrack/hatrack_config.h
+++ b/include/hatrack/hatrack_config.h
@@ -696,21 +696,6 @@
 
 #define CAPQ_MINIMUM_SIZE 256
 
-/* CAPQ_TOP_CONTEND_THRESHOLD
- * 
- * On calls to capq_top(), how many times do we retry in the face of
- * dequeue contention, before we linearize ourselves behind a dequeue?
- * This is necessary to make capq_top() wait free, but means that we
- * might return KNOWING that a subsequent call to capq_cap() is going
- * to fail, causing the caller to do some unnecessary work.
- *
- * For most expected uses of CAPQ, it's probably better to minimize
- * contention, and keep this number low, but I don't have any strong
- * evidence yet.
- */
-
-#define CAPQ_TOP_CONTEND_THRESHOLD 4
-
 /* CAPQ_TOP_SUSPEND_THRESHOLD
  *
  * If calls to capq_top() find that the underlying backing store is

--- a/include/hatrack/hatrack_config.h
+++ b/include/hatrack/hatrack_config.h
@@ -678,6 +678,23 @@
  */
 #undef HATSTACK_TEST_LLSTACK
 
+/* CAPQ_DEFAULT_SIZE
+ *
+ * Specifies the initial number of entries in a CAPQ store, if no size
+ * is provided.
+ */
+#define CAPQ_DEFAULT_SIZE 1024
+
+/* CAPQ_MINIMUM_SIZE
+ *
+ * Given the use of this for building wait-free algorithms, this is
+ * perhaps a bit higher than you might expect.  In early vector
+ * testing, this is the point where the performance impact is
+ * noticable; this value was originally set to 512, and maybe should
+ * go back there?
+ */
+
+#define CAPQ_MINIMUM_SIZE 256
 
 /* CAPQ_TOP_CONTEND_THRESHOLD
  * 


### PR DESCRIPTION
I've changed the overall capq implementation, refactoring it to ensure that calls to top() are wait-free, so that one can use this abstraction to implement other wait-free algorithms.

This actually simplified the algorithm and seems to have improved performance considerably as well.

Note that it's still possible to use this abstraction in a way that destroys the progress guarantees.  For example, I still provide a capq_dequeue operation built on top of top() plus compare-and-pop(), which is only lock-free (the operation mainly exists so that we can use the same code for testing capq as we do for other queues).